### PR TITLE
Implement API rate limiting to enhance backend security

### DIFF
--- a/middleware/rateLimiter.js
+++ b/middleware/rateLimiter.js
@@ -1,0 +1,41 @@
+const rateLimit = require('express-rate-limit');
+
+// For login and MFA
+const loginLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 10, 
+  message: {
+    status: 429,
+    error: "Too many login attempts, please try again after 10 minutes.",
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// For signup
+const signupLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 10,
+  message: {
+    status: 429,
+    error: "Too many signup attempts, please try again later.",
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+module.exports = { loginLimiter, signupLimiter };
+
+// For contact us and user feedback forms
+const formLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 20,
+    message: {
+      status: 429,
+      error: "Too many form submissions from this IP, please try again after an hour.",
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+  
+  module.exports = { loginLimiter, signupLimiter, formLimiter };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.1",
+        "express-rate-limit": "^7.5.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "mocha": "^10.7.0",
@@ -1027,6 +1028,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-safe-stringify": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.1",
+    "express-rate-limit": "^7.5.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "mocha": "^10.7.0",

--- a/routes/contactus.js
+++ b/routes/contactus.js
@@ -1,8 +1,9 @@
 const express = require("express");
-const router  = express.Router();
+const router = express.Router();
 const controller = require('../controller/contactusController.js');
+const { formLimiter } = require('../middleware/rateLimiter'); 
 
-router.route('/').post(function(req,res) {
+router.post('/', formLimiter, function(req, res) {
     controller.contactus(req, res);
 });
 

--- a/routes/login.js
+++ b/routes/login.js
@@ -1,11 +1,16 @@
 const express = require("express");
 const router = express.Router();
-const controller = require('../controller/loginController.js');
+const controller = require("../controller/loginController.js");
+const { loginLimiter } = require("../middleware/rateLimiter");
 
-router.route('/').post(function(req,res) {
-    controller.login(req, res);
-});
-router.route('/mfa').post(function(req,res) {
-    controller.loginMfa(req, res);
-});
+router.route('/')
+    .post(loginLimiter, function(req, res) {
+        controller.login(req, res);
+    });
+
+router.route('/mfa')
+    .post(loginLimiter, function(req, res) {
+        controller.loginMfa(req, res);
+    });
+
 module.exports = router;

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -1,9 +1,11 @@
 const express = require("express");
 const router = express.Router();
-const controller = require('../controller/signupController.js');
+const controller = require("../controller/signupController.js");
+const { signupLimiter } = require("../middleware/rateLimiter");
 
-router.route('/').post(function(req,res) {
-    controller.signup(req, res);
-});
+router.route('/')
+    .post(signupLimiter, function(req, res) {
+        controller.signup(req, res);
+    });
 
 module.exports = router;

--- a/routes/userfeedback.js
+++ b/routes/userfeedback.js
@@ -1,8 +1,9 @@
 const express = require("express");
-const router  = express.Router();
-const controller = require('../controller/userFeedbackController');
+const router = express.Router();
+const controller = require('../controller/userFeedbackController.js');
+const { formLimiter } = require('../middleware/rateLimiter');
 
-router.route('/').post(function(req,res) {
+router.post('/', formLimiter, function(req, res) {
     controller.userfeedback(req, res);
 });
 

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ app.use(helmet({
 
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: 1000,
   standardHeaders: true,
   legacyHeaders: false,
   message: {

--- a/server.js
+++ b/server.js
@@ -7,28 +7,44 @@ const yaml = require("yamljs");
 const { exec } = require("child_process");
 const bodyParser = require("body-parser");
 const multer = require("multer");
-
+const rateLimit = require('express-rate-limit'); 
 
 const app = express();
 const port = process.env.PORT || 80;
 
 let db = require("./dbConnection");
 
+
 app.options("*", cors({ origin: "http://localhost:3000" }));
 app.use(cors({ origin: "http://localhost:3000" }));
 
+
 app.use(helmet({
-	contentSecurityPolicy: {
-		directives: {
-			defaultSrc: ["'self'"],
-			scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
-			styleSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
-			objectSrc: ["'none'"],
-		},
-	},
-	crossOriginEmbedderPolicy: true,
-	referrerPolicy: { policy: "strict-origin-when-cross-origin" },
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
+      styleSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
+      objectSrc: ["'none'"],
+    },
+  },
+  crossOriginEmbedderPolicy: true,
+  referrerPolicy: { policy: "strict-origin-when-cross-origin" },
 }));
+
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    status: 429,
+    error: "Too many requests, please try again later.",
+  },
+});
+app.use(limiter);
+
 
 const swaggerDocument = yaml.load("./index.yaml");
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
@@ -36,10 +52,12 @@ app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.use(express.json({ limit: "50mb" }));
 app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
+
 const routes = require("./routes");
 routes(app);
 
+
 app.listen(port, async () => {
-	console.log(`Server is running on port ${port}`);
-	exec(`start http://localhost:${port}/api-docs`);
+  console.log(`Server is running on port ${port}`);
+  exec(`start http://localhost:${port}/api-docs`);
 });


### PR DESCRIPTION
This pull request enhances backend security while maintaining good user experience by applying route-specific rate limiting:

- /login and /login/mfa: 10 requests per 10 minutes per IP
- /signup: 10 requests per 10 minutes per IP
- /contactus and /userfeedback: 20 submissions per hour per IP
- Global limit: 1000 requests per 15 minutes per IP

All endpoints have been tested successfully via Swagger, confirming proper 429 responses after exceeding limits. This configuration protects against brute-force attacks, signup abuse, and form spamming while allowing legitimate user activity.

@valenLIU0214 — Please review this PR when you get a chance. Thank you!