### PR TITLE
Implement Role-Based Access Control (RBAC) with JWT Role Injection and Middleware

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -9,6 +9,8 @@ paths:
     post:
       summary: Upload a file
       description: Upload JPG, PNG, or PDF (max 5MB, limited to 5 uploads per 10 minutes)
+      security:
+        - BearerAuth: []
       requestBody:
         required: true
         content:

--- a/middleware/authorizeRoles.js
+++ b/middleware/authorizeRoles.js
@@ -1,0 +1,17 @@
+function authorizeRoles(...allowedRoles) {
+  return (req, res, next) => {
+    const userRole = req.user?.role;
+
+    if (!userRole) {
+      return res.status(403).json({ message: "Role missing in token" });
+    }
+
+    if (!allowedRoles.includes(userRole)) {
+      return res.status(403).json({ message: "Access denied: insufficient role" });
+    }
+
+    next();
+  };
+}
+
+module.exports = authorizeRoles; // ✅ make sure this line is present

--- a/routes/uploadRoutes.js
+++ b/routes/uploadRoutes.js
@@ -2,12 +2,23 @@ const express = require('express');
 const router = express.Router();
 const upload = require('../middleware/uploadMiddleware');
 const { uploadLimiter } = require('../rateLimiter');
- 
-router.post('/upload', uploadLimiter, upload.single('file'), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ message: 'No file uploaded' });
+
+const authenticateToken = require('../middleware/authenticateToken'); // ensures JWT is valid
+const authorizeRoles = require('../middleware/authorizeRoles');
+
+// ✅ Only admins can upload
+router.post(
+  '/upload',
+  authenticateToken,
+  authorizeRoles(9), // role_id = 9 is admin
+  uploadLimiter,
+  upload.single('file'),
+  (req, res) => {
+    if (!req.file) {
+      return res.status(400).json({ message: 'No file uploaded' });
+    }
+    res.status(200).json({ message: 'File uploaded successfully', file: req.file });
   }
-  res.status(200).json({ message: 'File uploaded successfully', file: req.file });
-});
- 
+);
+
 module.exports = router;


### PR DESCRIPTION
This update introduces Role-Based Access Control (RBAC) to the NutriHelp backend to enhance API endpoint security. Key changes include:

Added role_id and role_name to JWT payload during login for role verification in protected routes.

Created a reusable authorizeRoles() middleware to restrict access based on user role.

Applied middleware to the /upload route to allow only admin-level access (role_id = 9).

Updated Swagger documentation for protected routes to reflect RBAC requirements.

Verified functionality in Swagger with both authorised (admin) and unauthorised (non-admin) test cases.