### PR TITLE
BE17: Unified User Profile + Preference Summary Contract

### DIFF
--- a/controller/authController.js
+++ b/controller/authController.js
@@ -1,5 +1,6 @@
 const authService = require('../services/authService');
-const { isServiceError } = require('../services/serviceError');
+const { isServiceError, ServiceError } = require('../services/serviceError');
+const userProfileService = require('../services/userProfileService');
 const logger = require('../utils/logger');
 
 const TRUSTED_DEVICE_COOKIE = authService.trustedDeviceCookieName || 'trusted_device';
@@ -127,11 +128,21 @@ exports.revokeTrustedDevices = async (req, res) => {
 
 exports.getProfile = async (req, res) => {
   try {
-    const result = await authService.getProfile(req.user.userId);
+    const result = await userProfileService.getCanonicalProfile({ userId: req.user.userId });
     return res.json(result);
   } catch (error) {
+    if (error instanceof ServiceError) {
+      return res.status(error.statusCode).json({
+        success: false,
+        error: error.message
+      });
+    }
+
     logger.error('Get profile error', { error: error.message, userId: req.user?.userId });
-    return handleServiceError(res, error, 500, 'Get profile error:');
+    return res.status(500).json({
+      success: false,
+      error: 'Internal server error'
+    });
   }
 };
 

--- a/controller/userProfileController.js
+++ b/controller/userProfileController.js
@@ -1,83 +1,69 @@
-let { updateUser, saveImage } = require("../model/updateUserProfile.js");
-let getUser = require("../model/getUserProfile.js");
+const userProfileService = require('../services/userProfileService');
+const { ServiceError } = require('../services/serviceError');
+const logger = require('../utils/logger');
 
-/**
- * Update User Profile
- * - Normal users can update only their own profile (based on token email).
- * - Admins can update any profile by providing email in the body.
- */
-const updateUserProfile = async (req, res) => {
-	try {
-    const { role, email: tokenEmail } = req.user || {};
-    let targetEmail = req.body.email;
+function resolveTargetLookup(req) {
+  const isAdmin = req.user?.role === 'admin';
+  const explicitUserId = req.query.userId || req.body.targetUserId || req.body.userId || null;
+  const explicitEmail = req.query.email || req.body.targetEmail || null;
+  const legacyAdminEmailTarget = isAdmin && !req.body.profile && !explicitUserId && !explicitEmail
+    ? req.body.email
+    : null;
 
-    // Normal users must always use their own email
-    if (role !== "admin") {
-      targetEmail = tokenEmail;
-    }
-
-    if (!targetEmail) {
-      return res.status(400).json({ error: "Email is required" });
-    }
-
-    const userProfile = await updateUser(
-      req.body.name,
-      req.body.first_name,
-      req.body.last_name,
-      targetEmail,
-      req.body.contact_number,
-      req.body.address
-    );
-
-    if (!userProfile || userProfile.length === 0) {
-      return res.status(404).json({ error: "User not found" });
-    }
-
-    // If user image provided, save it and update image_url
-    if (req.body.user_image) {
-      const url = await saveImage(req.body.user_image, userProfile[0].user_id);
-      userProfile[0].image_url = url;
-    }
-
-    res.status(200).json(userProfile);
-  } catch (error) {
-    console.error("Error updating user profile:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (isAdmin && explicitUserId) {
+    return { userId: explicitUserId };
   }
-};
 
-/**
- * Get User Profile
- * - Normal users can only fetch their own profile (from token).
- * - Admins can fetch any profile using `?email=xxx`.
- */
+  if (isAdmin && (explicitEmail || legacyAdminEmailTarget)) {
+    return { email: explicitEmail || legacyAdminEmailTarget };
+  }
+
+  return { userId: req.user?.userId };
+}
+
+function handleProfileError(res, error, label, context = {}) {
+  if (error instanceof ServiceError) {
+    return res.status(error.statusCode).json({
+      success: false,
+      error: error.message
+    });
+  }
+
+  logger.error(label, { error: error.message, ...context });
+  return res.status(500).json({
+    success: false,
+    error: 'Internal server error'
+  });
+}
+
 const getUserProfile = async (req, res) => {
-	try {
-    const { role, email: tokenEmail } = req.user || {};
-    const { email: queryEmail } = req.query;
-
-    let targetEmail = tokenEmail;
-
-    // Admin can override with query email
-    if (role === "admin" && queryEmail) {
-      targetEmail = queryEmail;
-    }
-
-    if (!targetEmail) {
-      return res.status(400).json({ error: "Email is required" });
-    }
-
-    const userProfile = await getUser(targetEmail);
-
-    if (!userProfile) {
-      return res.status(404).json({ error: "User not found" });
-    }
-
-    res.status(200).json(userProfile);
+  try {
+    const response = await userProfileService.getCanonicalProfile(resolveTargetLookup(req));
+    return res.status(200).json(response);
   } catch (error) {
-    console.error("Error fetching user profile:", error);
-    res.status(500).json({ message: "Internal server error" });
+    return handleProfileError(res, error, 'Error fetching user profile', {
+      actorUserId: req.user?.userId
+    });
   }
 };
 
-module.exports = { updateUserProfile, getUserProfile };
+const updateUserProfile = async (req, res) => {
+  try {
+    const response = await userProfileService.updateCanonicalProfile({
+      actor: req.user,
+      targetLookup: resolveTargetLookup(req),
+      body: req.body
+    });
+
+    return res.status(200).json(response);
+  } catch (error) {
+    return handleProfileError(res, error, 'Error updating user profile', {
+      actorUserId: req.user?.userId
+    });
+  }
+};
+
+module.exports = {
+  getUserProfile,
+  updateUserProfile
+};

--- a/model/getUserProfile.js
+++ b/model/getUserProfile.js
@@ -1,16 +1,34 @@
 const supabase = require("../dbConnection.js");
 
-async function getUserProfile(email) {
+async function getUserProfile(lookup = {}) {
 	try {
-		let { data, error } = await supabase
+		const query = supabase
 			.from("users")
 			.select(
-				"user_id,name,first_name,last_name,email,contact_number,mfa_enabled,address,image_id"
-			)
-			.eq("email", email);
+				"user_id,name,first_name,last_name,email,contact_number,mfa_enabled,address,image_id,registration_date,last_login,account_status,user_roles!left(role_name)"
+			);
 
-		if (data[0].image_id != null) {
-			data[0].image_url = await getImageUrl(data[0].image_id);
+		if (lookup.userId != null) {
+			query.eq("user_id", lookup.userId);
+		} else if (lookup.email) {
+			query.eq("email", lookup.email);
+		} else {
+			throw new Error("A userId or email lookup is required");
+		}
+
+		const { data, error } = await query.maybeSingle();
+		if (error) {
+			throw error;
+		}
+
+		if (!data) {
+			return null;
+		}
+
+		if (data.image_id != null) {
+			data.image_url = await getImageUrl(data.image_id);
+		} else {
+			data.image_url = null;
 		}
 
 		return data;

--- a/model/updateUserProfile.js
+++ b/model/updateUserProfile.js
@@ -1,35 +1,45 @@
 const supabase = require("../dbConnection.js");
 const { decode } = require("base64-arraybuffer");
 
-async function updateUser(
-	name,
-	first_name,
-	last_name,
-	email,
-	contact_number,
-	address
-) {
-	let attributes = {};
-	attributes["name"] = name || undefined;
-	attributes["first_name"] = first_name || undefined;
-	attributes["last_name"] = last_name || undefined;
-	attributes["email"] = email || undefined;
-	attributes["contact_number"] = contact_number || undefined;
-	attributes["address"] = address || undefined;
+async function updateUser({ userId, attributes = {} }) {
+	const payload = Object.fromEntries(
+		Object.entries(attributes).filter(([, value]) => value !== undefined)
+	);
 
 	try {
-		let { data, error } = await supabase
+		if (!userId) {
+			throw new Error("userId is required");
+		}
+
+		if (Object.keys(payload).length === 0) {
+			const { data, error } = await supabase
+				.from("users")
+				.select(
+					"user_id,name,first_name,last_name,email,contact_number,mfa_enabled,address,image_id,registration_date,last_login,account_status,user_roles!left(role_name)"
+				)
+				.eq("user_id", userId)
+				.maybeSingle();
+
+			if (error) throw error;
+			return data;
+		}
+
+		const { data, error } = await supabase
 			.from("users")
-			.update(attributes) // e.g { email: "sample@email.com" }
-			.eq("email", email)
+			.update(payload)
+			.eq("user_id", userId)
 			.select(
-				"user_id,name,first_name,last_name,email,contact_number,mfa_enabled,address"
-			);
+				"user_id,name,first_name,last_name,email,contact_number,mfa_enabled,address,image_id,registration_date,last_login,account_status,user_roles!left(role_name)"
+			)
+			.maybeSingle();
+
+		if (error) throw error;
 		return data;
 	} catch (error) {
 		throw error;
 	}
 }
+
 async function saveImage(image, user_id) {
 	let file_name = `users/${user_id}.png`;
 	if (image === undefined || image === null) return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@sendgrid/mail": "8.1.3",
         "@supabase/supabase-js": "2.86.0",
+        "base64-arraybuffer": "^1.0.2",
         "bcrypt": "5.1.1",
         "bcryptjs": "2.4.3",
         "cors": "2.8.5",
@@ -29,6 +30,7 @@
         "sinon": "18.0.0",
         "swagger-ui-express": "5.0.0",
         "twilio": "5.9.0",
+        "winston": "^3.11.0",
         "yamljs": "0.3.0"
       },
       "devDependencies": {
@@ -37,6 +39,7 @@
         "mocha": "11.7.2",
         "nyc": "15.1.0",
         "prettier": "3.2.5",
+        "proxyquire": "^2.1.3",
         "supertest": "7.1.4",
         "swagger-cli": "4.0.4"
       }
@@ -611,6 +614,26 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -1022,6 +1045,8 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -1134,6 +1159,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.86.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.86.0.tgz",
@@ -1222,18 +1257,24 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/phoenix": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
       "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -1442,6 +1483,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1449,9 +1496,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -1465,10 +1512,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1497,19 +1553,6 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -1557,9 +1600,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1712,9 +1755,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001782",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
       "funding": [
         {
@@ -1849,6 +1892,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1869,6 +1925,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -1876,6 +1953,27 @@
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/combined-stream": {
@@ -2234,9 +2332,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.329",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
-      "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -2245,6 +2343,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2651,6 +2755,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -2685,6 +2795,20 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -2786,6 +2910,12 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -3121,9 +3251,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3417,6 +3547,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3449,6 +3595,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -3479,7 +3635,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3812,6 +3967,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3843,9 +4004,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
@@ -3919,6 +4080,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/long": {
@@ -4146,9 +4324,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4186,6 +4364,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4272,9 +4457,9 @@
       }
     },
     "node_modules/nise": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.4.tgz",
-      "integrity": "sha512-vSA4IpRHRWZkmotu61SvF45Jirq4CTLT3KKOWJPsPMtxtOBOlxcAlXfv/OrWxkzAJiCBrvdfWvGQjHT7r7+Qqg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -4284,18 +4469,18 @@
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.2.0.tgz",
-      "integrity": "sha512-+SM3gQi95RWZLlD+Npy/UC5mHftlXwnVJMRpMyiqjrF4yNnbvi/Ubh3x9sLw6gxWSuibOn00uiLu1CKozehWlQ==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
-      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4360,9 +4545,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4689,6 +4874,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -4844,6 +5038,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -4993,6 +5194,8 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
     "node_modules/prom-client": {
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
@@ -5026,6 +5229,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "node_modules/punycode": {
@@ -5183,6 +5398,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5284,6 +5521,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5434,13 +5680,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5588,6 +5834,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/statuses": {
@@ -5776,9 +6031,9 @@
       }
     },
     "node_modules/superagent/node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5817,6 +6072,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/swagger-cli": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/swagger-cli/-/swagger-cli-4.0.4.tgz",
@@ -5834,9 +6102,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.32.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.1.tgz",
-      "integrity": "sha512-6HQoo7+j8PA2QqP5kgAb9dl1uxUjvR0SAoL/WUp1sTEvm0F6D5npgU2OGCLwl++bIInqGlEUQ2mpuZRZYtyCzQ==",
+      "version": "5.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+      "integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
@@ -5942,6 +6210,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5963,6 +6237,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -6053,9 +6336,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -6235,6 +6518,70 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -19,17 +19,19 @@
     "validate": "npm run lint && npm run format:check && npm test && npm run openapi:validate && npm run security:audit"
   },
   "devDependencies": {
-    "eslint": "8.57.0",
-    "prettier": "3.2.5",
-    "mocha": "11.7.2",
     "chai": "6.0.1",
+    "eslint": "8.57.0",
+    "mocha": "11.7.2",
     "nyc": "15.1.0",
-    "swagger-cli": "4.0.4",
-    "supertest": "7.1.4"
+    "prettier": "3.2.5",
+    "proxyquire": "^2.1.3",
+    "supertest": "7.1.4",
+    "swagger-cli": "4.0.4"
   },
   "dependencies": {
     "@sendgrid/mail": "8.1.3",
     "@supabase/supabase-js": "2.86.0",
+    "base64-arraybuffer": "^1.0.2",
     "bcrypt": "5.1.1",
     "bcryptjs": "2.4.3",
     "cors": "2.8.5",

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -2,21 +2,14 @@ const express = require("express");
 const router = express.Router();
 const controller = require("../controller/userProfileController.js");
 const { authenticateToken } = require("../middleware/authenticateToken");
+const validate = require("../middleware/validateRequest");
+const { updateUserProfileValidation } = require("../validators/userProfileValidator");
 
 router.get("/", authenticateToken, (req, res) => {
-  req.params.userId = req.user.userId;
   return controller.getUserProfile(req, res);
 });
 
-router.put("/", authenticateToken, (req, res) => {
-  req.body.user_id = req.body.user_id || req.user.userId;
-  if (String(req.user.userId) !== String(req.body.user_id) && req.user.role !== "admin") {
-    return res.status(403).json({
-      success: false,
-      error: "Forbidden: You can only update your own profile",
-    });
-  }
-
+router.put("/", authenticateToken, updateUserProfileValidation, validate, (req, res) => {
   return controller.updateUserProfile(req, res);
 });
 

--- a/routes/userprofile.js
+++ b/routes/userprofile.js
@@ -4,29 +4,17 @@ const controller = require('../controller/userProfileController.js');
 const updateUserProfileController = require('../controller/updateUserProfileController.js');
 const { authenticateToken } = require('../middleware/authenticateToken');
 const authorizeRoles = require('../middleware/authorizeRoles');
+const validate = require('../middleware/validateRequest');
+const { updateUserProfileValidation } = require('../validators/userProfileValidator');
 
-// Get logged-in user's profile OR admin can get any profile via query param
 router.get('/', authenticateToken, (req, res) => {
-  // If admin → allow fetching with ?userId=xxx
-  if (req.user.role === 'admin' && req.query.userId) {
-    req.params.userId = req.query.userId;
-    return controller.getUserProfile(req, res);
-  }
-
-  // If normal user → only allow their own profile
-  req.params.userId = req.user.userId;
   return controller.getUserProfile(req, res);
 });
 
-// Update profile (user can only update their own, admin can update anyone)
-router.put('/', authenticateToken, (req, res) => {
-  if (req.user.role === 'admin' || req.user.userId == req.body.user_id) {
-    return controller.updateUserProfile(req, res);
-  }
-  return res.status(403).json({ success: false, error: 'Forbidden: You can only update your own profile' });
+router.put('/', authenticateToken, updateUserProfileValidation, validate, (req, res) => {
+  return controller.updateUserProfile(req, res);
 });
 
-// Update profile by unique identifier (admin only)
 router.put('/update-by-identifier',
   authenticateToken,
   authorizeRoles('admin'),

--- a/services/authService.js
+++ b/services/authService.js
@@ -4,6 +4,7 @@ const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 const logLoginEvent = require('../Monitor_&_Logging/loginLogger');
 const { ServiceError } = require('./serviceError');
+const userProfileService = require('./userProfileService');
 
 const supabaseAnon = createClient(
   process.env.SUPABASE_URL,
@@ -541,34 +542,7 @@ class AuthService {
       throw new ServiceError(400, 'User ID is required');
     }
 
-    const { data: user, error } = await supabaseAnon
-      .from('users')
-      .select(`
-        user_id, email, name, first_name, last_name,
-        registration_date, last_login, account_status,
-        user_roles!inner(role_name)
-      `)
-      .eq('user_id', userId)
-      .single();
-
-    if (error || !user) {
-      throw new ServiceError(404, 'User not found');
-    }
-
-    return {
-      success: true,
-      user: {
-        id: user.user_id,
-        email: user.email,
-        name: user.name,
-        firstName: user.first_name,
-        lastName: user.last_name,
-        role: user.user_roles?.role_name,
-        registrationDate: user.registration_date,
-        lastLogin: user.last_login,
-        accountStatus: user.account_status
-      }
-    };
+    return userProfileService.getCanonicalProfile({ userId });
   }
 
   async logLoginAttempt({ email, userId, success, ipAddress, createdAt }) {

--- a/services/recommendationService.js
+++ b/services/recommendationService.js
@@ -2,6 +2,11 @@ const supabase = require('../dbConnection');
 const fetchUserPreferences = require('../model/fetchUserPreferences');
 const getUserProfile = require('../model/getUserProfile');
 const {
+  buildCanonicalProfile,
+  buildPreferenceSummary,
+  normalizeNameList
+} = require('./userProfileService');
+const {
   AI_ADAPTER_VERSION,
   resolveAiRecommendationSignals
 } = require('./recommendationAiAdapter');
@@ -29,15 +34,6 @@ function compact(arr) {
 
 function unique(arr) {
   return [...new Set(compact(arr))];
-}
-
-function normalizeNameList(items) {
-  const normalizedItems = Array.isArray(items) ? items : [];
-  return unique(normalizedItems.map((item) => {
-    if (!item) return null;
-    if (typeof item === 'string') return item.trim().toLowerCase();
-    return item.name ? String(item.name).trim().toLowerCase() : null;
-  }));
 }
 
 function normalizeIdList(items) {
@@ -336,23 +332,15 @@ async function generateRecommendations({
   }
 
   const [profileRows, preferences, recentRecipeIds, candidateRecipes] = await Promise.all([
-    email ? getUserProfile(email) : Promise.resolve([]),
+    email ? getUserProfile({ email }) : Promise.resolve(null),
     fetchUserPreferences(userId),
     fetchRecentRecipeIds(userId),
     fetchCandidateRecipes(100)
   ]);
 
-  const profile = Array.isArray(profileRows) ? profileRows[0] || null : profileRows || null;
+  const profile = buildCanonicalProfile(profileRows);
   const preferenceData = preferences && typeof preferences === 'object' ? preferences : {};
-  const preferenceSummary = {
-    dietaryRequirements: normalizeNameList(preferenceData.dietary_requirements),
-    allergies: normalizeNameList(preferenceData.allergies),
-    cuisines: normalizeNameList(preferenceData.cuisines),
-    dislikes: normalizeNameList(preferenceData.dislikes),
-    healthConditions: normalizeNameList(preferenceData.health_conditions),
-    spiceLevels: normalizeNameList(preferenceData.spice_levels),
-    cookingMethods: normalizeNameList(preferenceData.cooking_methods)
-  };
+  const preferenceSummary = buildPreferenceSummary(preferenceData);
 
   const mergedGoalState = {
     ...goalState,

--- a/services/userProfileService.js
+++ b/services/userProfileService.js
@@ -1,0 +1,180 @@
+const getUserProfile = require('../model/getUserProfile');
+const { updateUser, saveImage } = require('../model/updateUserProfile');
+const fetchUserPreferences = require('../model/fetchUserPreferences');
+const { ServiceError } = require('./serviceError');
+
+const PROFILE_CONTRACT_VERSION = 'user-profile-v1';
+
+function normalizeString(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized === '' ? null : normalized;
+}
+
+function normalizeEmail(value) {
+  const normalized = normalizeString(value);
+  return normalized ? normalized.toLowerCase() : normalized;
+}
+
+function normalizeNameList(items) {
+  const source = Array.isArray(items) ? items : [];
+  return [...new Set(source
+    .map((item) => {
+      if (!item) return null;
+      if (typeof item === 'string') return item.trim().toLowerCase();
+      if (typeof item === 'object' && item.name != null) return String(item.name).trim().toLowerCase();
+      return null;
+    })
+    .filter(Boolean))];
+}
+
+function toFullName(parts) {
+  return parts.filter(Boolean).join(' ').trim() || null;
+}
+
+function buildCanonicalProfile(profile) {
+  if (!profile) {
+    return null;
+  }
+
+  const firstName = profile.first_name ?? null;
+  const lastName = profile.last_name ?? null;
+  const fullName = toFullName([firstName, lastName]) || profile.name || null;
+
+  return {
+    id: profile.user_id,
+    email: profile.email ?? null,
+    username: profile.name ?? null,
+    firstName,
+    lastName,
+    fullName,
+    contactNumber: profile.contact_number ?? null,
+    address: profile.address ?? null,
+    imageUrl: profile.image_url ?? null,
+    role: profile.user_roles?.role_name || profile.role || null,
+    mfaEnabled: Boolean(profile.mfa_enabled),
+    accountStatus: profile.account_status ?? null,
+    registrationDate: profile.registration_date ?? null,
+    lastLogin: profile.last_login ?? null
+  };
+}
+
+function buildPreferenceSummary(preferences) {
+  const source = preferences && typeof preferences === 'object' ? preferences : {};
+
+  const summary = {
+    dietaryRequirements: normalizeNameList(source.dietary_requirements),
+    allergies: normalizeNameList(source.allergies),
+    cuisines: normalizeNameList(source.cuisines),
+    dislikes: normalizeNameList(source.dislikes),
+    healthConditions: normalizeNameList(source.health_conditions),
+    spiceLevels: normalizeNameList(source.spice_levels),
+    cookingMethods: normalizeNameList(source.cooking_methods)
+  };
+
+  return {
+    ...summary,
+    hasPreferences: Object.values(summary).some((items) => items.length > 0)
+  };
+}
+
+function buildProfileResponse(profile, preferences) {
+  const canonicalProfile = buildCanonicalProfile(profile);
+  const preferenceSummary = buildPreferenceSummary(preferences);
+
+  return {
+    success: true,
+    contractVersion: PROFILE_CONTRACT_VERSION,
+    profile: canonicalProfile,
+    preferenceSummary
+  };
+}
+
+function extractProfileInput(body = {}) {
+  const source = body.profile && typeof body.profile === 'object' ? body.profile : body;
+
+  return {
+    username: normalizeString(source.username ?? source.name),
+    firstName: normalizeString(source.firstName ?? source.first_name),
+    lastName: normalizeString(source.lastName ?? source.last_name),
+    email: normalizeEmail(source.email),
+    contactNumber: normalizeString(source.contactNumber ?? source.contact_number),
+    address: normalizeString(source.address),
+    userImage: source.userImage ?? source.user_image
+  };
+}
+
+function hasProfileUpdates(input) {
+  return Object.values(input).some((value) => value !== undefined);
+}
+
+async function findProfileOrThrow(lookup) {
+  const profile = await getUserProfile(lookup);
+  if (!profile) {
+    throw new ServiceError(404, 'User not found');
+  }
+
+  return profile;
+}
+
+async function getCanonicalProfile(lookup) {
+  const profile = await findProfileOrThrow(lookup);
+  const preferences = await fetchUserPreferences(profile.user_id);
+  return buildProfileResponse(profile, preferences);
+}
+
+async function updateCanonicalProfile({ actor, targetLookup, body }) {
+  const existingProfile = await findProfileOrThrow(targetLookup);
+  const updates = extractProfileInput(body);
+
+  if (!hasProfileUpdates(updates)) {
+    throw new ServiceError(400, 'At least one profile field is required');
+  }
+
+  const attributes = {
+    name: updates.username,
+    first_name: updates.firstName,
+    last_name: updates.lastName,
+    email: updates.email,
+    contact_number: updates.contactNumber,
+    address: updates.address
+  };
+
+  const updatedProfile = await updateUser({
+    userId: existingProfile.user_id,
+    attributes
+  });
+
+  const mergedProfile = updatedProfile || existingProfile;
+
+  if (updates.userImage) {
+    mergedProfile.image_url = await saveImage(updates.userImage, existingProfile.user_id);
+  }
+
+  const preferences = await fetchUserPreferences(existingProfile.user_id);
+
+  return {
+    ...buildProfileResponse(mergedProfile, preferences),
+    meta: {
+      updatedBy: actor?.userId || null
+    }
+  };
+}
+
+module.exports = {
+  PROFILE_CONTRACT_VERSION,
+  buildCanonicalProfile,
+  buildPreferenceSummary,
+  buildProfileResponse,
+  extractProfileInput,
+  getCanonicalProfile,
+  normalizeNameList,
+  updateCanonicalProfile
+};

--- a/test/authControllerServiceBoundary.test.js
+++ b/test/authControllerServiceBoundary.test.js
@@ -109,16 +109,19 @@ describe('Auth controller service boundaries', () => {
   });
 
   it('delegates profile lookups to authService', async () => {
-    const authService = {
+    const userProfileService = {
       '@noCallThru': true,
-      getProfile: sinon.stub().resolves({
+      getCanonicalProfile: sinon.stub().resolves({
         success: true,
-        user: { id: 1, email: 'user@example.com' }
+        contractVersion: 'user-profile-v1',
+        profile: { id: 1, email: 'user@example.com' },
+        preferenceSummary: { allergies: [], hasPreferences: false }
       })
     };
 
     const controller = proxyquire('../controller/authController', {
-      '../services/authService': authService
+      '../services/authService': { '@noCallThru': {} },
+      '../services/userProfileService': userProfileService
     });
 
     const req = {
@@ -130,10 +133,12 @@ describe('Auth controller service boundaries', () => {
 
     await controller.getProfile(req, res);
 
-    expect(authService.getProfile.calledOnceWith(1)).to.equal(true);
+    expect(userProfileService.getCanonicalProfile.calledOnceWith({ userId: 1 })).to.equal(true);
     expect(res.json.calledWith({
       success: true,
-      user: { id: 1, email: 'user@example.com' }
+      contractVersion: 'user-profile-v1',
+      profile: { id: 1, email: 'user@example.com' },
+      preferenceSummary: { allergies: [], hasPreferences: false }
     })).to.equal(true);
   });
 });

--- a/test/authProfileController.test.js
+++ b/test/authProfileController.test.js
@@ -1,0 +1,42 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+describe('Auth Profile Controller', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns the shared canonical profile contract', async () => {
+    const userProfileService = {
+      getCanonicalProfile: sinon.stub().resolves({
+        success: true,
+        contractVersion: 'user-profile-v1',
+        profile: { id: 3, email: 'user@example.com' },
+        preferenceSummary: { allergies: [], hasPreferences: false }
+      })
+    };
+
+    const controller = proxyquire('../controller/authController', {
+      '../services/authService': { '@noCallThru': {} },
+      '../services/userProfileService': userProfileService
+    });
+
+    const req = {
+      user: { userId: 3 }
+    };
+    const res = {
+      json: sinon.stub()
+    };
+
+    await controller.getProfile(req, res);
+
+    expect(userProfileService.getCanonicalProfile.calledOnceWith({ userId: 3 })).to.equal(true);
+    expect(res.json.calledWith({
+      success: true,
+      contractVersion: 'user-profile-v1',
+      profile: { id: 3, email: 'user@example.com' },
+      preferenceSummary: { allergies: [], hasPreferences: false }
+    })).to.equal(true);
+  });
+});

--- a/test/recommendationService.test.js
+++ b/test/recommendationService.test.js
@@ -84,7 +84,7 @@ describe('Recommendation Service', () => {
         spice_levels: [],
         cooking_methods: [{ id: 3, name: 'Grilled' }]
       }),
-      '../model/getUserProfile': async () => ([{ user_id: 5, email: 'user@example.com', first_name: 'Alex' }]),
+      '../model/getUserProfile': async () => ({ user_id: 5, email: 'user@example.com', first_name: 'Alex' }),
       './recommendationAiAdapter': {
         AI_ADAPTER_VERSION: 'v1',
         resolveAiRecommendationSignals: async () => ({
@@ -124,6 +124,15 @@ describe('Recommendation Service', () => {
     expect(result.recommendations[0].explanation).to.include('preferred cuisine');
     expect(result.recommendations[0].metadata.sourceTags).to.include('request');
     expect(result.source.ai.applied).to.equal(true);
+    expect(result.userContext.profile).to.deep.include({
+      id: 5,
+      email: 'user@example.com',
+      firstName: 'Alex'
+    });
+    expect(result.userContext.preferences).to.deep.include({
+      cuisines: ['mediterranean'],
+      hasPreferences: true
+    });
   });
 
   it('returns cached results for repeated requests', async () => {
@@ -175,7 +184,7 @@ describe('Recommendation Service', () => {
         spice_levels: [],
         cooking_methods: []
       }),
-      '../model/getUserProfile': async () => ([{ user_id: 8, email: 'cache@example.com' }]),
+      '../model/getUserProfile': async () => ({ user_id: 8, email: 'cache@example.com' }),
       './recommendationAiAdapter': {
         AI_ADAPTER_VERSION: 'v1',
         resolveAiRecommendationSignals: async () => ({
@@ -227,7 +236,7 @@ describe('Recommendation Service', () => {
         spice_levels: [],
         cooking_methods: []
       }),
-      '../model/getUserProfile': async () => ([{ user_id: 12, email: 'fallback@example.com' }]),
+      '../model/getUserProfile': async () => ({ user_id: 12, email: 'fallback@example.com' }),
       './recommendationAiAdapter': {
         AI_ADAPTER_VERSION: 'v1',
         resolveAiRecommendationSignals: async () => ({
@@ -277,7 +286,7 @@ describe('Recommendation Service', () => {
         }]
       }),
       '../model/fetchUserPreferences': async () => null,
-      '../model/getUserProfile': async () => ([{ user_id: 12, email: 'fallback@example.com' }]),
+      '../model/getUserProfile': async () => ({ user_id: 12, email: 'fallback@example.com' }),
       './recommendationAiAdapter': proxyquire('../services/recommendationAiAdapter', {})
     });
 
@@ -316,7 +325,7 @@ describe('Recommendation Service', () => {
         }
       },
       '../model/fetchUserPreferences': async () => ({}),
-      '../model/getUserProfile': async () => ([{ user_id: 8, email: 'cache@example.com' }]),
+      '../model/getUserProfile': async () => ({ user_id: 8, email: 'cache@example.com' }),
       './recommendationAiAdapter': {
         AI_ADAPTER_VERSION: 'v1',
         resolveAiRecommendationSignals: async () => ({
@@ -361,7 +370,7 @@ describe('Recommendation Service', () => {
         }]
       }),
       '../model/fetchUserPreferences': async () => ({}),
-      '../model/getUserProfile': async () => ([{ user_id: 5, email: 'user@example.com', first_name: 'Alex' }]),
+      '../model/getUserProfile': async () => ({ user_id: 5, email: 'user@example.com', first_name: 'Alex' }),
       './recommendationAiAdapter': proxyquire('../services/recommendationAiAdapter', {})
     });
 

--- a/test/userProfileService.test.js
+++ b/test/userProfileService.test.js
@@ -1,0 +1,127 @@
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+
+describe('User Profile Service', () => {
+  it('builds a canonical profile contract with normalized preference summary', async () => {
+    const service = proxyquire('../services/userProfileService', {
+      '../model/getUserProfile': async () => ({
+        user_id: 7,
+        email: 'user@example.com',
+        name: 'alex-user',
+        first_name: 'Alex',
+        last_name: 'Nguyen',
+        contact_number: '0400000000',
+        address: 'Melbourne',
+        image_url: 'https://cdn.example.com/profile.png',
+        account_status: 'active',
+        registration_date: '2025-01-01T00:00:00.000Z',
+        last_login: '2026-04-01T00:00:00.000Z',
+        mfa_enabled: true,
+        user_roles: { role_name: 'user' }
+      }),
+      '../model/fetchUserPreferences': async () => ({
+        dietary_requirements: [{ id: 1, name: 'High Protein' }],
+        allergies: [{ id: 2, name: 'Peanut' }],
+        cuisines: [],
+        dislikes: [],
+        health_conditions: [{ id: 4, name: 'Diabetes' }],
+        spice_levels: [],
+        cooking_methods: [{ id: 8, name: 'Grilled' }]
+      }),
+      '../model/updateUserProfile': {}
+    });
+
+    const result = await service.getCanonicalProfile({ userId: 7 });
+
+    expect(result).to.deep.equal({
+      success: true,
+      contractVersion: 'user-profile-v1',
+      profile: {
+        id: 7,
+        email: 'user@example.com',
+        username: 'alex-user',
+        firstName: 'Alex',
+        lastName: 'Nguyen',
+        fullName: 'Alex Nguyen',
+        contactNumber: '0400000000',
+        address: 'Melbourne',
+        imageUrl: 'https://cdn.example.com/profile.png',
+        role: 'user',
+        mfaEnabled: true,
+        accountStatus: 'active',
+        registrationDate: '2025-01-01T00:00:00.000Z',
+        lastLogin: '2026-04-01T00:00:00.000Z'
+      },
+      preferenceSummary: {
+        dietaryRequirements: ['high protein'],
+        allergies: ['peanut'],
+        cuisines: [],
+        dislikes: [],
+        healthConditions: ['diabetes'],
+        spiceLevels: [],
+        cookingMethods: ['grilled'],
+        hasPreferences: true
+      }
+    });
+  });
+
+  it('maps legacy update payload fields into the shared model update call', async () => {
+    const updateUser = async ({ userId, attributes }) => ({
+      user_id: userId,
+      name: attributes.name,
+      first_name: attributes.first_name,
+      last_name: attributes.last_name,
+      email: attributes.email,
+      contact_number: attributes.contact_number,
+      address: attributes.address,
+      image_url: null,
+      mfa_enabled: false,
+      account_status: 'active',
+      user_roles: { role_name: 'user' }
+    });
+
+    const service = proxyquire('../services/userProfileService', {
+      '../model/getUserProfile': async () => ({
+        user_id: 12,
+        email: 'legacy@example.com',
+        name: 'legacy',
+        user_roles: { role_name: 'user' }
+      }),
+      '../model/updateUserProfile': {
+        updateUser,
+        saveImage: async () => 'https://cdn.example.com/new.png'
+      },
+      '../model/fetchUserPreferences': async () => ({
+        dietary_requirements: [],
+        allergies: [],
+        cuisines: [],
+        dislikes: [],
+        health_conditions: [],
+        spice_levels: [],
+        cooking_methods: []
+      })
+    });
+
+    const result = await service.updateCanonicalProfile({
+      actor: { userId: 12 },
+      targetLookup: { userId: 12 },
+      body: {
+        first_name: 'Legacy',
+        last_name: 'User',
+        contact_number: '12345',
+        address: 'Geelong',
+        user_image: 'base64-image'
+      }
+    });
+
+    expect(result.profile).to.deep.include({
+      id: 12,
+      firstName: 'Legacy',
+      lastName: 'User',
+      contactNumber: '12345',
+      address: 'Geelong',
+      imageUrl: 'https://cdn.example.com/new.png'
+    });
+    expect(result.meta).to.deep.equal({ updatedBy: 12 });
+  });
+});

--- a/test/userProfileTests.js
+++ b/test/userProfileTests.js
@@ -1,56 +1,173 @@
-require("dotenv").config();
-const chai = require("chai");
-const chaiHttp = require("chai-http");
-const { addTestUser, deleteTestUser, getToken } = require("./test-helpers");
-const { expect } = chai;
-chai.use(chaiHttp);
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
 
-describe("User Profile Tests", () => {
-	let testUser;
+const { ServiceError } = require('../services/serviceError');
 
-	before(async function () {
-		testUser = await addTestUser();
-	});
-	after(async function () {
-		await deleteTestUser(testUser.user_id);
-	});
-	it("should return 200, Update user profile Successful", (done) => {
-		let req = {
-			email: testUser.email,
-			first_name: "updated_name",
-			last_name: "updated_last_name",
-			contact_number: "111111111"
-		};
-		chai.request("http://localhost:80")
-			.put("/api/userprofile")
-			.send(req)
-			.end((err, res) => {
-				if (err) return done(err);
-				expect(res).to.have.status(200);
-				expect(res.body[0]).to.have.property(
-					"first_name",
-					req.first_name
-				);
-				expect(res.body[0]).to.have.property(
-					"last_name",
-					req.last_name
-				);
-				expect(res.body[0]).to.have.property("email", req.email);
-				expect(res.body[0]).to.have.property(
-					"contact_number",
-					req.contact_number
-				);
-				done();
-			});
-	});
-	it("should return 400, Missing username", (done) => {
-		let req = {};
-		chai.request("http://localhost:80")
-			.put("/api/userprofile")
-			.send(req)
-			.end((err, res) => {
-				expect(res).to.have.status(400);
-				done();
-			});
-	});
+describe('User Profile Controller', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns the canonical profile contract for the authenticated user', async () => {
+    const userProfileService = {
+      getCanonicalProfile: sinon.stub().resolves({
+        success: true,
+        contractVersion: 'user-profile-v1',
+        profile: {
+          id: 42,
+          email: 'user@example.com',
+          firstName: 'Alex'
+        },
+        preferenceSummary: {
+          dietaryRequirements: ['high protein'],
+          allergies: [],
+          hasPreferences: true
+        }
+      })
+    };
+
+    const controller = proxyquire('../controller/userProfileController', {
+      '../services/userProfileService': userProfileService,
+      '../utils/logger': { error: sinon.stub() }
+    });
+
+    const req = {
+      user: { userId: 42, role: 'user', email: 'user@example.com' },
+      query: {},
+      body: {}
+    };
+    const res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub()
+    };
+
+    await controller.getUserProfile(req, res);
+
+    expect(userProfileService.getCanonicalProfile.calledOnceWith({ userId: 42 })).to.equal(true);
+    expect(res.status.calledWith(200)).to.equal(true);
+    expect(res.json.firstCall.args[0]).to.deep.equal({
+      success: true,
+      contractVersion: 'user-profile-v1',
+      profile: {
+        id: 42,
+        email: 'user@example.com',
+        firstName: 'Alex'
+      },
+      preferenceSummary: {
+        dietaryRequirements: ['high protein'],
+        allergies: [],
+        hasPreferences: true
+      }
+    });
+  });
+
+  it('allows admins to target another user by email on read', async () => {
+    const userProfileService = {
+      getCanonicalProfile: sinon.stub().resolves({
+        success: true,
+        contractVersion: 'user-profile-v1',
+        profile: { id: 9, email: 'target@example.com' },
+        preferenceSummary: { allergies: [], hasPreferences: false }
+      })
+    };
+
+    const controller = proxyquire('../controller/userProfileController', {
+      '../services/userProfileService': userProfileService,
+      '../utils/logger': { error: sinon.stub() }
+    });
+
+    const req = {
+      user: { userId: 1, role: 'admin', email: 'admin@example.com' },
+      query: { email: 'target@example.com' },
+      body: {}
+    };
+    const res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub()
+    };
+
+    await controller.getUserProfile(req, res);
+
+    expect(userProfileService.getCanonicalProfile.calledOnceWith({ email: 'target@example.com' })).to.equal(true);
+    expect(res.status.calledWith(200)).to.equal(true);
+  });
+
+  it('maps canonical update payloads through the shared service', async () => {
+    const userProfileService = {
+      updateCanonicalProfile: sinon.stub().resolves({
+        success: true,
+        contractVersion: 'user-profile-v1',
+        profile: { id: 42, firstName: 'Updated' },
+        preferenceSummary: { allergies: [], hasPreferences: false },
+        meta: { updatedBy: 42 }
+      })
+    };
+
+    const controller = proxyquire('../controller/userProfileController', {
+      '../services/userProfileService': userProfileService,
+      '../utils/logger': { error: sinon.stub() }
+    });
+
+    const req = {
+      user: { userId: 42, role: 'user', email: 'user@example.com' },
+      query: {},
+      body: {
+        profile: {
+          firstName: 'Updated',
+          contactNumber: '12345678'
+        }
+      }
+    };
+    const res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub()
+    };
+
+    await controller.updateUserProfile(req, res);
+
+    expect(userProfileService.updateCanonicalProfile.calledOnce).to.equal(true);
+    expect(userProfileService.updateCanonicalProfile.firstCall.args[0]).to.deep.equal({
+      actor: { userId: 42, role: 'user', email: 'user@example.com' },
+      targetLookup: { userId: 42 },
+      body: {
+        profile: {
+          firstName: 'Updated',
+          contactNumber: '12345678'
+        }
+      }
+    });
+    expect(res.status.calledWith(200)).to.equal(true);
+  });
+
+  it('returns stable service errors for invalid updates', async () => {
+    const logger = { error: sinon.stub() };
+    const userProfileService = {
+      updateCanonicalProfile: sinon.stub().rejects(new ServiceError(400, 'At least one profile field is required'))
+    };
+
+    const controller = proxyquire('../controller/userProfileController', {
+      '../services/userProfileService': userProfileService,
+      '../utils/logger': logger
+    });
+
+    const req = {
+      user: { userId: 42, role: 'user', email: 'user@example.com' },
+      query: {},
+      body: {}
+    };
+    const res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub()
+    };
+
+    await controller.updateUserProfile(req, res);
+
+    expect(res.status.calledWith(400)).to.equal(true);
+    expect(res.json.calledWith({
+      success: false,
+      error: 'At least one profile field is required'
+    })).to.equal(true);
+    expect(logger.error.called).to.equal(false);
+  });
 });

--- a/validators/userProfileValidator.js
+++ b/validators/userProfileValidator.js
@@ -1,0 +1,45 @@
+const { body } = require('express-validator');
+
+function optionalField(selector) {
+  return body(selector)
+    .optional({ nullable: true })
+    .isString()
+    .withMessage(`${selector} must be a string`)
+    .trim();
+}
+
+const updateUserProfileValidation = [
+  optionalField('name'),
+  optionalField('username'),
+  optionalField('first_name'),
+  optionalField('firstName'),
+  optionalField('last_name'),
+  optionalField('lastName'),
+  optionalField('contact_number'),
+  optionalField('contactNumber'),
+  optionalField('address'),
+  optionalField('user_image'),
+  optionalField('userImage'),
+  body('email')
+    .optional({ nullable: true })
+    .isEmail()
+    .withMessage('email must be a valid email address')
+    .normalizeEmail(),
+  body('profile').optional().isObject().withMessage('profile must be an object'),
+  body('profile.name').optional({ nullable: true }).isString().withMessage('profile.name must be a string').trim(),
+  body('profile.username').optional({ nullable: true }).isString().withMessage('profile.username must be a string').trim(),
+  body('profile.firstName').optional({ nullable: true }).isString().withMessage('profile.firstName must be a string').trim(),
+  body('profile.lastName').optional({ nullable: true }).isString().withMessage('profile.lastName must be a string').trim(),
+  body('profile.contactNumber').optional({ nullable: true }).isString().withMessage('profile.contactNumber must be a string').trim(),
+  body('profile.address').optional({ nullable: true }).isString().withMessage('profile.address must be a string').trim(),
+  body('profile.userImage').optional({ nullable: true }).isString().withMessage('profile.userImage must be a string'),
+  body('profile.email')
+    .optional({ nullable: true })
+    .isEmail()
+    .withMessage('profile.email must be a valid email address')
+    .normalizeEmail()
+];
+
+module.exports = {
+  updateUserProfileValidation
+};


### PR DESCRIPTION
 **Summary**
- Implemented a unified backend user profile contract in `Nutrihelp-api`.
- Standardized profile responses across auth/profile endpoints to return a consistent `profile` and `preferenceSummary` shape.
- Preserved compatibility with older profile update payloads while adding a reusable normalized preference summary for recommendation-related features.

**What files changed**
- Added `services/userProfileService.js` to centralize canonical profile shaping and preference summary generation.
- Added `validators/userProfileValidator.js` for basic profile update validation.
- Updated `controller/userProfileController.js` and `controller/authController.js` to use the shared profile contract.
- Updated `services/authService.js` to delegate profile reads to the shared profile service.
- Updated `routes/profile.js` and `routes/userprofile.js` so both routes follow the same backend behavior.
- Updated `model/getUserProfile.js` and `model/updateUserProfile.js` to support standardized lookup and persistence flow.
- Updated `services/recommendationService.js` to reuse the normalized profile/preference summary instead of reshaping data ad hoc.
- Added or updated tests in `test/userProfileTests.js`, `test/userProfileService.test.js`, `test/authProfileController.test.js`, `test/authControllerServiceBoundary.test.js`, and `test/recommendationService.test.js`.
- Added `proxyquire` as a dev dependency to support the new unit tests.

**Validation**
- Ran focused backend tests for the new profile contract, controller behavior, service normalization, and recommendation integration.
- Command used: `npx mocha test/userProfileTests.js test/userProfileService.test.js test/authProfileController.test.js test/recommendationService.test.js --timeout 10000`