### PR TITLE
BE24: harden backend security operations and automated responses

### DIFF
--- a/middleware/authenticateToken.js
+++ b/middleware/authenticateToken.js
@@ -1,15 +1,53 @@
 const authService = require('../services/authService');
+const logger = require('../utils/logger');
+const { recordAuthInvalidTokenAttempt } = require('../Monitor_&_Logging/metrics');
+const {
+  getActiveBlock,
+  registerAuthFailure,
+} = require('../services/securityEvents/securityResponseService');
+
+const getClientIp = (req) => {
+  return (
+    req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+    req.ip ||
+    req.connection?.remoteAddress ||
+    'unknown'
+  );
+};
 
 /**
  * Access Token Authentication Middleware
  * - Verifies JWT access tokens only
  * - Attaches decoded user payload to req.user
  */
-const authenticateToken = (req, res, next) => {
+const authenticateToken = async (req, res, next) => {
   try {
     const authHeader = req.headers.authorization;
+    const ip = getClientIp(req);
+    const activeBlock = getActiveBlock(req);
+
+    if (activeBlock) {
+      logger.warn('Blocked request rejected during token authentication', {
+        route: req.path,
+        ip,
+        eventType: activeBlock.eventType,
+      });
+      return res.status(429).json({
+        success: false,
+        error: 'This IP has been temporarily blocked for security reasons.',
+        code: 'SECURITY_TEMPORARY_BLOCK',
+        blockedUntil: activeBlock.expiresAt,
+      });
+    }
 
     if (!authHeader) {
+      recordAuthInvalidTokenAttempt({
+        route: req.path,
+        ip,
+        reason: 'TOKEN_MISSING',
+      });
+      await registerAuthFailure(req, { reason: 'TOKEN_MISSING' });
+      logger.warn('Authorization header missing', { route: req.path, ip });
       return res.status(401).json({
         success: false,
         error: 'Authorization header missing',
@@ -19,6 +57,13 @@ const authenticateToken = (req, res, next) => {
 
     const parts = authHeader.split(' ');
     if (parts.length !== 2 || parts[0] !== 'Bearer') {
+      recordAuthInvalidTokenAttempt({
+        route: req.path,
+        ip,
+        reason: 'INVALID_AUTH_HEADER',
+      });
+      await registerAuthFailure(req, { reason: 'INVALID_AUTH_HEADER' });
+      logger.warn('Invalid authorization header format', { route: req.path, ip });
       return res.status(401).json({
         success: false,
         error: 'Invalid authorization format',
@@ -32,6 +77,13 @@ const authenticateToken = (req, res, next) => {
 
     // Ensure only access tokens are accepted
     if (!decoded || decoded.type !== 'access') {
+      recordAuthInvalidTokenAttempt({
+        route: req.path,
+        ip,
+        reason: 'INVALID_TOKEN_TYPE',
+      });
+      await registerAuthFailure(req, { reason: 'INVALID_TOKEN_TYPE' });
+      logger.warn('Invalid token type detected', { route: req.path, ip });
       return res.status(401).json({
         success: false,
         error: 'Invalid token type',
@@ -41,6 +93,13 @@ const authenticateToken = (req, res, next) => {
 
     // Validate payload
     if (!decoded.userId || !decoded.role) {
+      recordAuthInvalidTokenAttempt({
+        route: req.path,
+        ip,
+        reason: 'INVALID_TOKEN',
+      });
+      await registerAuthFailure(req, { reason: 'INVALID_TOKEN' });
+      logger.warn('Invalid token payload', { route: req.path, ip });
       return res.status(401).json({
         success: false,
         error: 'Invalid token payload',
@@ -57,6 +116,20 @@ const authenticateToken = (req, res, next) => {
 
     next();
   } catch (error) {
+    const ip = getClientIp(req);
+    const reason = error?.name || 'TOKEN_INVALID';
+    recordAuthInvalidTokenAttempt({
+      route: req.path,
+      ip,
+      reason,
+    });
+    await registerAuthFailure(req, { reason });
+    logger.warn('Access token verification failed', {
+      route: req.path,
+      ip,
+      reason,
+      message: error?.message,
+    });
     return res.status(401).json({
       success: false,
       error: 'Invalid or expired access token',

--- a/middleware/authorizeRoles.js
+++ b/middleware/authorizeRoles.js
@@ -1,12 +1,12 @@
 /**
  * Role-based access control (RBAC) middleware with violation logging
  */
-const { createClient } = require('@supabase/supabase-js');
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY // ✅ still using anon key
-);
+const { supabaseService } = require('../services/supabaseClient');
+const logger = require('../utils/logger');
+const {
+  getClientIp,
+  registerRbacViolation,
+} = require('../services/securityEvents/securityResponseService');
 
 function authorizeRoles(...allowedRoles) {
   return async (req, res, next) => {
@@ -14,6 +14,10 @@ function authorizeRoles(...allowedRoles) {
 
     if (!userRole) {
       await logViolation(req, userRole, "ROLE_MISSING");
+      await registerRbacViolation(req, {
+        status: 'ROLE_MISSING',
+        allowedRoles,
+      });
       return res.status(403).json({
         success: false,
         error: "Role missing in token",
@@ -26,6 +30,10 @@ function authorizeRoles(...allowedRoles) {
 
     if (!normalizedAllowed.includes(roleValue)) {
       await logViolation(req, roleValue, "ACCESS_DENIED");
+      await registerRbacViolation(req, {
+        status: 'ACCESS_DENIED',
+        allowedRoles: normalizedAllowed,
+      });
       return res.status(403).json({
         success: false,
         error: "Access denied: insufficient role",
@@ -41,24 +49,32 @@ function authorizeRoles(...allowedRoles) {
 async function logViolation(req, role, status) {
   const payload = {
     user_id: req.user?.userId || "unknown",
-    email: req.user?.email || "unknown",    // ✅ added email
+    email: req.user?.email || "unknown",
     role: role || "unknown",
     endpoint: req.originalUrl,
     method: req.method,
-    status
+    status,
+    ip_address: getClientIp(req),
+    created_at: new Date().toISOString(),
   };
 
   try {
-    const { error } = await supabase.from("rbac_violation_logs").insert([payload]);
+    const { error } = await supabaseService.from("rbac_violation_logs").insert([payload]);
     if (error) {
-      console.error("❌ Supabase insert error:", error.message);
+      logger.warn("Failed to persist RBAC violation log", {
+        message: error.message,
+        endpoint: payload.endpoint,
+        role: payload.role,
+      });
     } else {
-      console.log("✅ RBAC violation logged:", payload);
+      logger.warn("RBAC violation logged", payload);
     }
   } catch (err) {
-    console.error("❌ RBAC log exception:", err.message);
+    logger.logError("RBAC log exception", err, {
+      endpoint: payload.endpoint,
+      role: payload.role,
+    });
   }
 }
 
 module.exports = authorizeRoles;
-

--- a/rateLimiter.js
+++ b/rateLimiter.js
@@ -1,12 +1,22 @@
 // rateLimiter.js
 const rateLimit = require('express-rate-limit');
- 
+const {
+  registerUploadAbuse,
+} = require('./services/securityEvents/securityResponseService');
+
 const uploadLimiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes
   max: 3, // Limit to 3 uploads per 10 mins
-  message: {
-    success: false,
-    message: 'Too many uploads from this IP. Please try again later.',
+  handler: async (req, res) => {
+    await registerUploadAbuse(req, {
+      reason: 'UPLOAD_RATE_LIMIT_EXCEEDED',
+    });
+
+    return res.status(429).json({
+      success: false,
+      message: 'Too many uploads from this IP. Please try again later.',
+      code: 'UPLOAD_RATE_LIMIT_EXCEEDED',
+    });
   },
   standardHeaders: true,
   legacyHeaders: false,

--- a/routes/securityEvents.js
+++ b/routes/securityEvents.js
@@ -2,10 +2,19 @@
 
 const express = require('express');
 const router = express.Router();
+const { authenticateToken } = require('../middleware/authenticateToken');
+const authorizeRoles = require('../middleware/authorizeRoles');
+const {
+  createBlockMiddleware,
+} = require('../services/securityEvents/securityResponseService');
 
 const {
   exportSecurityEvents,
 } = require('../controller/securityEventsController');
+
+router.use(createBlockMiddleware());
+router.use(authenticateToken);
+router.use(authorizeRoles('admin'));
 
 // GET /security/events/export
 router.get('/events/export', exportSecurityEvents);

--- a/routes/systemRoutes.js
+++ b/routes/systemRoutes.js
@@ -2,6 +2,15 @@ const express = require('express');
 const router = express.Router();
 const { checkFileIntegrity, generateBaseline } = require('../tools/integrity/integrityService');
 const testErrorRouter = require('./testError');
+const { authenticateToken } = require('../middleware/authenticateToken');
+const authorizeRoles = require('../middleware/authorizeRoles');
+const {
+  createBlockMiddleware,
+} = require('../services/securityEvents/securityResponseService');
+
+router.use(createBlockMiddleware());
+router.use(authenticateToken);
+router.use(authorizeRoles('admin'));
 
 /**
  * @swagger

--- a/routes/uploadRoutes.js
+++ b/routes/uploadRoutes.js
@@ -6,16 +6,46 @@ const { uploadLimiter } = require('../rateLimiter');
 
 const { authenticateToken } = require("../middleware/authenticateToken");
 const authorizeRoles = require('../middleware/authorizeRoles');
+const {
+  createBlockMiddleware,
+  registerUploadAbuse,
+} = require('../services/securityEvents/securityResponseService');
+
+const secureUploadSingle = (fieldName) => {
+  const uploadSingle = upload.single(fieldName);
+
+  return async (req, res, next) => {
+    uploadSingle(req, res, async (error) => {
+      if (error) {
+        await registerUploadAbuse(req, {
+          reason: 'UPLOAD_VALIDATION_FAILED',
+          message: error.message,
+        });
+        return res.status(400).json({
+          success: false,
+          message: error.message,
+          code: 'UPLOAD_VALIDATION_FAILED',
+        });
+      }
+
+      return next();
+    });
+  };
+};
 
 // ✅ Only admins can upload
 router.post(
   '/upload',
+  createBlockMiddleware(),
   authenticateToken,
   authorizeRoles("admin"),   // 👈 use role name, not ID
   uploadLimiter,
-  upload.single('file'),
-  (req, res) => {
+  secureUploadSingle('file'),
+  async (req, res) => {
     if (!req.file) {
+      await registerUploadAbuse(req, {
+        reason: 'UPLOAD_FILE_MISSING',
+      });
       return res.status(400).json({ message: 'No file uploaded' });
     }
     res.status(200).json({ message: 'File uploaded successfully', file: req.file });

--- a/services/securityEvents/securityResponseService.js
+++ b/services/securityEvents/securityResponseService.js
@@ -1,0 +1,204 @@
+const logger = require('../../utils/logger');
+const authService = require('../authService');
+
+const WINDOW_MS = 10 * 60 * 1000;
+const IP_BLOCK_MS = 15 * 60 * 1000;
+
+const EVENT_CONFIG = {
+  auth_failure: {
+    threshold: 8,
+    eventCode: 'AUTH_FAILURE_THRESHOLD_EXCEEDED',
+    blockMessage: 'Too many authentication failures detected from this IP.',
+  },
+  rbac_violation: {
+    threshold: 5,
+    eventCode: 'RBAC_VIOLATION_THRESHOLD_EXCEEDED',
+    blockMessage: 'Too many permission denials detected from this IP.',
+  },
+  upload_abuse: {
+    threshold: 3,
+    eventCode: 'UPLOAD_ABUSE_THRESHOLD_EXCEEDED',
+    blockMessage: 'Too many abusive upload attempts detected from this IP.',
+  },
+};
+
+const eventBuckets = new Map();
+const blockedIps = new Map();
+
+const getClientIp = (req) => {
+  return (
+    req?.headers?.['x-forwarded-for']?.split(',')[0]?.trim() ||
+    req?.ip ||
+    req?.connection?.remoteAddress ||
+    'unknown'
+  );
+};
+
+const getBucketKey = (eventType, req, subject) => {
+  const ip = getClientIp(req);
+  return `${eventType}:${subject || req?.user?.userId || ip}`;
+};
+
+const pruneBuckets = () => {
+  const now = Date.now();
+  for (const [key, entry] of eventBuckets.entries()) {
+    if (now - entry.start > WINDOW_MS * 2) {
+      eventBuckets.delete(key);
+    }
+  }
+};
+
+const pruneBlocks = () => {
+  const now = Date.now();
+  for (const [ip, entry] of blockedIps.entries()) {
+    if (entry.expiresAt <= now) {
+      blockedIps.delete(ip);
+    }
+  }
+};
+
+const tickBucket = (eventType, req, subject) => {
+  const key = getBucketKey(eventType, req, subject);
+  const now = Date.now();
+  const current = eventBuckets.get(key);
+
+  if (!current || now - current.start > WINDOW_MS) {
+    const next = { count: 1, start: now };
+    eventBuckets.set(key, next);
+    return next.count;
+  }
+
+  current.count += 1;
+  return current.count;
+};
+
+const blockIp = ({ ip, eventType, metadata = {} }) => {
+  const expiresAt = Date.now() + IP_BLOCK_MS;
+  blockedIps.set(ip, {
+    eventType,
+    expiresAt,
+    metadata,
+  });
+
+  logger.warn('Applied temporary security IP block', {
+    ip,
+    eventType,
+    expiresAt: new Date(expiresAt).toISOString(),
+    ...metadata,
+  });
+};
+
+const triggerAccountProtection = async ({ req, eventType, metadata = {} }) => {
+  const userId = req?.user?.userId || metadata.userId;
+  if (!userId) {
+    return;
+  }
+
+  try {
+    await authService.logoutAll(userId, {
+      reason: `security_response:${eventType}`,
+      deviceInfo: {
+        ip: getClientIp(req),
+        userAgent: req?.headers?.['user-agent'] || 'unknown',
+      },
+    });
+
+    logger.warn('Revoked active sessions after security threshold breach', {
+      userId,
+      eventType,
+      route: req?.originalUrl || req?.path,
+    });
+  } catch (error) {
+    logger.logError('Failed to revoke sessions during security response', error, {
+      userId,
+      eventType,
+    });
+  }
+};
+
+const registerEvent = async ({ eventType, req, subject, metadata = {} }) => {
+  const config = EVENT_CONFIG[eventType];
+  if (!config) {
+    return { triggered: false };
+  }
+
+  const ip = getClientIp(req);
+  const count = tickBucket(eventType, req, subject);
+  pruneBuckets();
+  pruneBlocks();
+
+  if (count !== config.threshold) {
+    return { triggered: false, count };
+  }
+
+  blockIp({
+    ip,
+    eventType,
+    metadata: {
+      eventCode: config.eventCode,
+      route: req?.originalUrl || req?.path,
+      ...metadata,
+    },
+  });
+
+  await triggerAccountProtection({ req, eventType, metadata });
+
+  return {
+    triggered: true,
+    count,
+    eventCode: config.eventCode,
+    expiresAt: new Date(Date.now() + IP_BLOCK_MS).toISOString(),
+  };
+};
+
+const getActiveBlock = (req) => {
+  pruneBlocks();
+  const ip = getClientIp(req);
+  const block = blockedIps.get(ip);
+
+  if (!block) {
+    return null;
+  }
+
+  return {
+    ip,
+    eventType: block.eventType,
+    expiresAt: new Date(block.expiresAt).toISOString(),
+    metadata: block.metadata,
+  };
+};
+
+const createBlockMiddleware = () => {
+  return (req, res, next) => {
+    const block = getActiveBlock(req);
+    if (!block) {
+      return next();
+    }
+
+    const config = EVENT_CONFIG[block.eventType] || {};
+    return res.status(429).json({
+      success: false,
+      error: config.blockMessage || 'This IP has been temporarily blocked for security reasons.',
+      code: 'SECURITY_TEMPORARY_BLOCK',
+      blockedUntil: block.expiresAt,
+    });
+  };
+};
+
+const resetForTests = () => {
+  eventBuckets.clear();
+  blockedIps.clear();
+};
+
+module.exports = {
+  __resetForTests: resetForTests,
+  createBlockMiddleware,
+  getActiveBlock,
+  getClientIp,
+  registerAuthFailure: (req, metadata = {}) =>
+    registerEvent({ eventType: 'auth_failure', req, metadata }),
+  registerRbacViolation: (req, metadata = {}) =>
+    registerEvent({ eventType: 'rbac_violation', req, subject: req?.user?.userId, metadata }),
+  registerUploadAbuse: (req, metadata = {}) =>
+    registerEvent({ eventType: 'upload_abuse', req, subject: req?.user?.userId, metadata }),
+};

--- a/test/securityResponseService.test.js
+++ b/test/securityResponseService.test.js
@@ -1,0 +1,69 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://example.supabase.co';
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'service-role-key';
+process.env.JWT_TOKEN = process.env.JWT_TOKEN || 'test-jwt-secret';
+
+const authService = require('../services/authService');
+const securityResponseService = require('../services/securityEvents/securityResponseService');
+
+describe('securityResponseService', () => {
+  let logoutAllStub;
+
+  beforeEach(() => {
+    securityResponseService.__resetForTests();
+    logoutAllStub = sinon.stub(authService, 'logoutAll').resolves({ success: true });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    securityResponseService.__resetForTests();
+  });
+
+  it('temporarily blocks an IP after repeated auth failures', async () => {
+    const req = {
+      path: '/api/system/integrity-check',
+      headers: {
+        'x-forwarded-for': '203.0.113.1',
+        'user-agent': 'mocha-test',
+      },
+    };
+
+    for (let i = 0; i < 8; i += 1) {
+      await securityResponseService.registerAuthFailure(req, {
+        reason: 'TOKEN_INVALID',
+      });
+    }
+
+    const block = securityResponseService.getActiveBlock(req);
+    expect(block).to.not.equal(null);
+    expect(block.eventType).to.equal('auth_failure');
+    expect(logoutAllStub.called).to.equal(false);
+  });
+
+  it('revokes active sessions after repeated RBAC violations for the same user', async () => {
+    const req = {
+      originalUrl: '/api/security/events/export',
+      method: 'GET',
+      headers: {
+        'x-forwarded-for': '203.0.113.9',
+        'user-agent': 'mocha-test',
+      },
+      user: {
+        userId: 'user-123',
+      },
+    };
+
+    for (let i = 0; i < 5; i += 1) {
+      await securityResponseService.registerRbacViolation(req, {
+        status: 'ACCESS_DENIED',
+      });
+    }
+
+    expect(logoutAllStub.calledOnce).to.equal(true);
+    expect(logoutAllStub.firstCall.args[0]).to.equal('user-123');
+    expect(securityResponseService.getActiveBlock(req)?.eventType).to.equal('rbac_violation');
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens backend security operations by protecting privileged security routes and introducing automated responses for repeated high-risk events.

## Scope

This branch is rebased onto `master` and contains only the backend security hardening work for BE24.

## What changed

- Protected privileged backend routes with authentication and admin-only RBAC:
  - `routes/securityEvents.js`
  - `routes/systemRoutes.js`
- Added a shared security response service:
  - `services/securityEvents/securityResponseService.js`
- Added automated backend responses for repeated suspicious activity:
  - repeated authentication failures
  - repeated RBAC violations
  - repeated upload abuse
- Added temporary IP blocking for flagged actors
- Revoked active sessions when repeated RBAC/security violations cross thresholds
- Hardened upload handling:
  - blocks flagged IPs before upload processing
  - records abusive upload patterns from rate-limit and validation failures
  - returns stable backend error codes for abuse scenarios
- Improved RBAC violation logging:
  - uses shared Supabase service client
  - records IP and timestamp
  - emits structured log events
- Added focused regression coverage for the new automated security response logic

## Files changed

- `middleware/authenticateToken.js`
- `middleware/authorizeRoles.js`
- `rateLimiter.js`
- `routes/securityEvents.js`
- `routes/systemRoutes.js`
- `routes/uploadRoutes.js`
- `services/securityEvents/securityResponseService.js`
- `test/securityResponseService.test.js`

## Why this matters

The backend already had monitoring and metrics in place, but repeated suspicious activity was still mostly passive. This PR moves those flows toward explicit operational response and tightens access around sensitive security and system endpoints.

## Validation

- `node -c middleware/authenticateToken.js`
- `npx mocha ./test/securityResponseService.test.js --timeout 5000 --exit`

## Notes

- This PR is intentionally scoped to backend security hardening only.
- Existing OpenAPI issues in `index.yaml` were not addressed here.