### PR TITLE
fix: HTTP fallback in local dev when TLS certs are absent

### DIFF
--- a/server.js
+++ b/server.js
@@ -224,11 +224,16 @@ function createHttpsServer() {
 
     return https.createServer(tlsOptions, app);
   } catch (error) {
-    console.error('Failed to start HTTPS server with TLS 1.3 enforcement.');
-    console.error(`Expected TLS key at: ${tlsKeyPath}`);
-    console.error(`Expected TLS cert at: ${tlsCertPath}`);
-    console.error(error.message);
-    process.exit(1);
+    if (process.env.NODE_ENV === 'production') {
+      console.error('Failed to start HTTPS server with TLS 1.3 enforcement.');
+      console.error(`Expected TLS key at: ${tlsKeyPath}`);
+      console.error(`Expected TLS cert at: ${tlsCertPath}`);
+      console.error(error.message);
+      process.exit(1);
+    }
+    console.warn('⚠️  TLS certs not found — falling back to HTTP for local development.');
+    console.warn(`   Generate certs with: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout certs/local-key.pem -out certs/local-cert.pem -subj "//CN=localhost"`);
+    return null;
   }
 }
 
@@ -242,30 +247,39 @@ function createRedirectServer() {
 }
 
 const httpsServer = createHttpsServer();
-const redirectServer = createRedirectServer();
+const useHttpFallback = httpsServer === null;
+const activePort = useHttpFallback ? HTTP_PORT : HTTPS_PORT;
+const activeServer = useHttpFallback ? http.createServer(app) : httpsServer;
 
-httpsServer.listen(HTTPS_PORT, async () => {
+if (!useHttpFallback) {
+  const redirectServer = createRedirectServer();
+  redirectServer.on('error', (err) => {
+    if (err.code === 'EACCES' || err.code === 'EADDRINUSE') {
+      console.warn(`⚠️ HTTP redirect server could not start on port ${HTTP_PORT} (${err.code}).`);
+      return;
+    }
+    throw err;
+  });
+  redirectServer.listen(HTTP_PORT);
+}
+
+activeServer.listen(activePort, async () => {
   console.log('\n🎉 NutriHelp API launched successfully!');
   console.log('='.repeat(50));
-  console.log(`🔒 HTTPS server running on port ${HTTPS_PORT} (TLS 1.3 only)`);
-  console.log(`🔁 HTTP redirect server running on port ${HTTP_PORT}`);
-  console.log(`📚 Swagger UI: https://localhost:${HTTPS_PORT}/api-docs`);
+  if (useHttpFallback) {
+    console.log(`🔓 HTTP server running on port ${activePort} (dev mode — no TLS)`);
+    console.log(`📚 Swagger UI: http://localhost:${activePort}/api-docs`);
+  } else {
+    console.log(`🔒 HTTPS server running on port ${activePort} (TLS 1.3 only)`);
+    console.log(`🔁 HTTP redirect server running on port ${HTTP_PORT}`);
+    console.log(`📚 Swagger UI: https://localhost:${activePort}/api-docs`);
+  }
   console.log('='.repeat(50));
   console.log('💡 Press Ctrl+C to stop the server \n');
 
   if (process.platform === 'win32') {
-    exec(`start https://localhost:${HTTPS_PORT}/api-docs`);
+    const proto = useHttpFallback ? 'http' : 'https';
+    exec(`start ${proto}://localhost:${activePort}/api-docs`);
   }
 });
 
-redirectServer.on('error', (err) => {
-  if (err.code === 'EACCES' || err.code === 'EADDRINUSE') {
-    console.warn(`⚠️ HTTP redirect server could not start on port ${HTTP_PORT} (${err.code}).`);
-    console.warn(`⚠️ HTTPS API is still running. For local testing, use https://localhost:${HTTPS_PORT} directly.`);
-    console.warn('⚠️ Optionally set HTTP_PORT=8081 in .env to test redirect without admin permissions.');
-    return;
-  }
-  throw err;
-});
-
-redirectServer.listen(HTTP_PORT);


### PR DESCRIPTION
## Summary
- `server.js` now falls back to a plain HTTP server on `HTTP_PORT` when TLS certs are not found and `NODE_ENV` is not `production`
- Previously the server called `process.exit(1)`, which forced developers to generate self-signed certs — those certs then caused `net::ERR_CERT_AUTHORITY_INVALID` in the browser, blocking all API calls including CORS preflight
- Production (Render) is unaffected: Render terminates TLS at the edge; the Node process there runs HTTP internally regardless

## Test plan
- [ ] Run `npm run start` locally with no certs in `certs/` — server should start on HTTP port 8081 with a warning
- [ ] Browser API calls (login, etc.) should succeed without cert errors
- [ ] On Render, deploy and confirm HTTPS still works via Render's edge proxy