### PR TITLE
feat(BE36): Connect AI Meal Suggestions to Daily Meal Plan

### DIFF
--- a/controller/mealplanController.js
+++ b/controller/mealplanController.js
@@ -1,5 +1,6 @@
 const { validationResult } = require('express-validator');
 let { add, get, deletePlan, saveMealRelation } = require('../model/mealPlan.js');
+const { addAiMealItem, getAiMealItems, deleteAiMealItem } = require('../model/aiMealPlanItem.js');
 const {
   createErrorResponse,
   createSuccessResponse,
@@ -89,4 +90,78 @@ const deleteMealPlan = async (req, res) => {
   }
 };
 
-module.exports = { addMealPlan, getMealPlan, deleteMealPlan };
+const addAiMealSuggestion = async (req, res) => {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return validationFailure(res, errors);
+    }
+
+    const userId = req.user?.userId;
+    if (!userId) {
+      return res.status(401).json(createErrorResponse('Unauthorized', 'UNAUTHORIZED'));
+    }
+
+    const item = await addAiMealItem(userId, req.body);
+
+    return res.status(201).json(createSuccessResponse(
+      { item },
+      { message: 'AI meal suggestion saved to your daily plan' }
+    ));
+  } catch (error) {
+    console.error('[mealplanController] addAiMealSuggestion error:', error);
+    return internalFailure(res, 'AI_MEAL_SAVE_FAILED');
+  }
+};
+
+const getAiMealSuggestions = async (req, res) => {
+  try {
+    const userId = req.user?.userId;
+    if (!userId) {
+      return res.status(401).json(createErrorResponse('Unauthorized', 'UNAUTHORIZED'));
+    }
+
+    const items = await getAiMealItems(userId);
+
+    return res.status(200).json(createSuccessResponse(
+      { items },
+      { count: items.length }
+    ));
+  } catch (error) {
+    console.error('[mealplanController] getAiMealSuggestions error:', error);
+    return internalFailure(res, 'AI_MEALS_LOAD_FAILED');
+  }
+};
+
+const deleteAiMealSuggestion = async (req, res) => {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return validationFailure(res, errors);
+    }
+
+    const userId = req.user?.userId;
+    if (!userId) {
+      return res.status(401).json(createErrorResponse('Unauthorized', 'UNAUTHORIZED'));
+    }
+
+    await deleteAiMealItem(req.body.id, userId);
+
+    return res.status(200).json(createSuccessResponse(
+      null,
+      { message: 'AI meal suggestion removed from your daily plan' }
+    ));
+  } catch (error) {
+    console.error('[mealplanController] deleteAiMealSuggestion error:', error);
+    return internalFailure(res, 'AI_MEAL_DELETE_FAILED');
+  }
+};
+
+module.exports = {
+  addMealPlan,
+  getMealPlan,
+  deleteMealPlan,
+  addAiMealSuggestion,
+  getAiMealSuggestions,
+  deleteAiMealSuggestion,
+};

--- a/index.yaml
+++ b/index.yaml
@@ -1705,6 +1705,199 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /mealplan/ai-suggestion:
+    post:
+      summary: Save AI meal suggestion to daily plan
+      description: Saves a single AI-generated meal (from the /meal page) into the user's daily meal plan. Accessible by all authenticated users.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - meal_type
+                - name
+              properties:
+                meal_type:
+                  type: string
+                  enum: [breakfast, lunch, dinner, snack]
+                  example: breakfast
+                day:
+                  type: string
+                  example: Monday
+                name:
+                  type: string
+                  example: Oat Porridge with Berries
+                description:
+                  type: string
+                  example: High-fibre low-sodium breakfast
+                calories:
+                  type: number
+                  example: 320
+                proteins:
+                  type: number
+                  example: 12
+                fats:
+                  type: number
+                  example: 6
+                sodium:
+                  type: number
+                  example: 180
+                fiber:
+                  type: number
+                  example: 5
+                vitamins:
+                  type: string
+                  example: Vitamin D, Vitamin B12
+                ingredients:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      item:
+                        type: string
+                        example: oats
+                      amount:
+                        type: string
+                        example: 80g
+      responses:
+        '201':
+          description: AI meal suggestion saved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    get:
+      summary: Get saved AI meal suggestions
+      description: Returns all AI-generated meals the logged-in user has saved to their daily plan.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: AI meal suggestions fetched successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                            user_id:
+                              type: integer
+                            meal_type:
+                              type: string
+                            day:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            calories:
+                              type: number
+                            proteins:
+                              type: number
+                            fats:
+                              type: number
+                            sodium:
+                              type: number
+                            fiber:
+                              type: number
+                            vitamins:
+                              type: string
+                            ingredients:
+                              type: array
+                            created_at:
+                              type: string
+                              format: date-time
+                      count:
+                        type: integer
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: Remove a saved AI meal suggestion
+      description: Deletes a specific AI meal suggestion from the user's daily plan by ID.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+              properties:
+                id:
+                  type: integer
+                  example: 1
+      responses:
+        '200':
+          description: AI meal suggestion deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /recipe:
     post:
       summary: Get all recipes

--- a/migrations/create_ai_meal_plan_items.sql
+++ b/migrations/create_ai_meal_plan_items.sql
@@ -1,0 +1,32 @@
+-- Migration: create ai_meal_plan_items table
+-- Run this in the Supabase SQL editor before deploying the new endpoints.
+
+CREATE TABLE IF NOT EXISTS ai_meal_plan_items (
+  id          BIGSERIAL PRIMARY KEY,
+  user_id     BIGINT        NOT NULL,
+  meal_type   TEXT          NOT NULL CHECK (meal_type IN ('breakfast', 'lunch', 'dinner', 'snack')),
+  day         TEXT,
+  name        TEXT          NOT NULL,
+  description TEXT,
+  calories    NUMERIC,
+  proteins    NUMERIC,
+  fats        NUMERIC,
+  sodium      NUMERIC,
+  fiber       NUMERIC,
+  vitamins    TEXT,
+  ingredients JSONB         DEFAULT '[]',
+  created_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+-- Index for fast per-user queries
+CREATE INDEX IF NOT EXISTS idx_ai_meal_plan_items_user_id
+  ON ai_meal_plan_items (user_id);
+
+-- RLS: users can only see and modify their own rows
+ALTER TABLE ai_meal_plan_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own AI meal items"
+  ON ai_meal_plan_items
+  FOR ALL
+  USING (user_id = auth.uid()::BIGINT)
+  WITH CHECK (user_id = auth.uid()::BIGINT);

--- a/model/aiMealPlanItem.js
+++ b/model/aiMealPlanItem.js
@@ -1,0 +1,48 @@
+const supabase = require('../dbConnection.js');
+
+async function addAiMealItem(userId, item) {
+  const { data, error } = await supabase
+    .from('ai_meal_plan_items')
+    .insert({
+      user_id: userId,
+      meal_type: item.meal_type,
+      day: item.day || null,
+      name: item.name,
+      description: item.description || null,
+      calories: item.calories ?? null,
+      proteins: item.proteins ?? null,
+      fats: item.fats ?? null,
+      sodium: item.sodium ?? null,
+      fiber: item.fiber ?? null,
+      vitamins: item.vitamins || null,
+      ingredients: item.ingredients || [],
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+async function getAiMealItems(userId) {
+  const { data, error } = await supabase
+    .from('ai_meal_plan_items')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  return data || [];
+}
+
+async function deleteAiMealItem(id, userId) {
+  const { error } = await supabase
+    .from('ai_meal_plan_items')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', userId);
+
+  if (error) throw error;
+}
+
+module.exports = { addAiMealItem, getAiMealItems, deleteAiMealItem };

--- a/routes/mealplan.js
+++ b/routes/mealplan.js
@@ -1,11 +1,15 @@
 const express = require("express");
 const router  = express.Router();
 const { coreApp } = require('../controller');
-const { 
-    addMealPlanValidation, 
-    getMealPlanValidation, 
-    deleteMealPlanValidation 
+const {
+    addMealPlanValidation,
+    getMealPlanValidation,
+    deleteMealPlanValidation
 } = require('../validators/mealplanValidator.js');
+const {
+    addAiMealSuggestionValidation,
+    deleteAiMealSuggestionValidation,
+} = require('../validators/aiMealSuggestionValidator.js');
 const validate = require('../middleware/validateRequest.js');
 
 // 🔑 Import authentication + RBAC
@@ -17,29 +21,51 @@ const { mealplan: controller } = coreApp;
 // Route to add a meal plan (Nutritionist + Admin)
 router.route('/')
     .post(
-        authenticateToken, 
-        authorizeRoles("nutritionist", "admin"), 
-        addMealPlanValidation, 
-        validate, 
+        authenticateToken,
+        authorizeRoles("nutritionist", "admin"),
+        addMealPlanValidation,
+        validate,
         (req, res) => controller.addMealPlan(req, res)
     )
 
 // Route to get a meal plan (User + Nutritionist + Admin)
     .get(
-        authenticateToken, 
-        authorizeRoles("user", "nutritionist", "admin"), 
-        getMealPlanValidation, 
-        validate, 
+        authenticateToken,
+        authorizeRoles("user", "nutritionist", "admin"),
+        getMealPlanValidation,
+        validate,
         (req, res) => controller.getMealPlan(req, res)
     )
 
 // Route to delete a meal plan (Admin only)
     .delete(
-        authenticateToken, 
-        authorizeRoles("admin"), 
-        deleteMealPlanValidation, 
-        validate, 
+        authenticateToken,
+        authorizeRoles("admin"),
+        deleteMealPlanValidation,
+        validate,
         (req, res) => controller.deleteMealPlan(req, res)
+    );
+
+// AI meal suggestion routes — accessible by all authenticated users
+router.route('/ai-suggestion')
+    .post(
+        authenticateToken,
+        authorizeRoles("user", "nutritionist", "admin"),
+        addAiMealSuggestionValidation,
+        validate,
+        (req, res) => controller.addAiMealSuggestion(req, res)
+    )
+    .get(
+        authenticateToken,
+        authorizeRoles("user", "nutritionist", "admin"),
+        (req, res) => controller.getAiMealSuggestions(req, res)
+    )
+    .delete(
+        authenticateToken,
+        authorizeRoles("user", "nutritionist", "admin"),
+        deleteAiMealSuggestionValidation,
+        validate,
+        (req, res) => controller.deleteAiMealSuggestion(req, res)
     );
 
 module.exports = router;

--- a/services/securityEvents/securityResponseService.js
+++ b/services/securityEvents/securityResponseService.js
@@ -25,6 +25,18 @@ const EVENT_CONFIG = {
 const eventBuckets = new Map();
 const blockedIps = new Map();
 
+const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1', 'localhost']);
+
+const isLocalhostRequest = (req) => {
+  if (process.env.NODE_ENV === 'production') return false;
+  const ip =
+    req?.headers?.['x-forwarded-for']?.split(',')[0]?.trim() ||
+    req?.ip ||
+    req?.connection?.remoteAddress ||
+    '';
+  return LOOPBACK_IPS.has(ip);
+};
+
 const getClientIp = (req) => {
   return (
     req?.headers?.['x-forwarded-for']?.split(',')[0]?.trim() ||
@@ -170,6 +182,8 @@ const getActiveBlock = (req) => {
 
 const createBlockMiddleware = () => {
   return (req, res, next) => {
+    if (isLocalhostRequest(req)) return next();
+
     const block = getActiveBlock(req);
     if (!block) {
       return next();

--- a/validators/aiMealSuggestionValidator.js
+++ b/validators/aiMealSuggestionValidator.js
@@ -1,0 +1,65 @@
+const { body } = require('express-validator');
+
+const addAiMealSuggestionValidation = [
+  body('meal_type')
+    .notEmpty().withMessage('meal_type is required')
+    .isString().withMessage('meal_type must be a string')
+    .isIn(['breakfast', 'lunch', 'dinner', 'snack'])
+    .withMessage('meal_type must be breakfast, lunch, dinner, or snack'),
+
+  body('name')
+    .notEmpty().withMessage('name is required')
+    .isString().withMessage('name must be a string')
+    .isLength({ max: 255 }).withMessage('name must be 255 characters or fewer'),
+
+  body('day')
+    .optional()
+    .isString().withMessage('day must be a string'),
+
+  body('description')
+    .optional()
+    .isString().withMessage('description must be a string'),
+
+  body('calories')
+    .optional()
+    .isNumeric().withMessage('calories must be a number'),
+
+  body('proteins')
+    .optional()
+    .isNumeric().withMessage('proteins must be a number'),
+
+  body('fats')
+    .optional()
+    .isNumeric().withMessage('fats must be a number'),
+
+  body('sodium')
+    .optional()
+    .isNumeric().withMessage('sodium must be a number'),
+
+  body('fiber')
+    .optional()
+    .isNumeric().withMessage('fiber must be a number'),
+
+  body('ingredients')
+    .optional()
+    .isArray().withMessage('ingredients must be an array'),
+
+  body('ingredients.*.item')
+    .optional()
+    .isString().withMessage('each ingredient item must be a string'),
+
+  body('ingredients.*.amount')
+    .optional()
+    .isString().withMessage('each ingredient amount must be a string'),
+];
+
+const deleteAiMealSuggestionValidation = [
+  body('id')
+    .notEmpty().withMessage('id is required')
+    .isInt({ min: 1 }).withMessage('id must be a positive integer'),
+];
+
+module.exports = {
+  addAiMealSuggestionValidation,
+  deleteAiMealSuggestionValidation,
+};


### PR DESCRIPTION
## Overview

The AI meal plan feature on the `/meal` page already generates high-quality 7-day meal suggestions via Gemini/Groq, but users had no way to carry those suggestions into their actual Daily Meal Plan. This PR closes that gap by adding a dedicated save/retrieve/delete flow for AI-generated meals, keeping it cleanly separated from the existing nutritionist-managed meal plan system.

## What Changed

### New endpoints — `POST | GET | DELETE /api/mealplan/ai-suggestion`

| Method | Auth | Description |
|--------|------|-------------|
| `POST` | Any authenticated user | Save a single AI-generated meal to the user's daily plan |
| `GET` | Any authenticated user | Fetch all saved AI meals for the logged-in user |
| `DELETE` | Any authenticated user | Remove a saved AI meal by ID |

All three endpoints are documented in Swagger (`index.yaml`).

### New Supabase table — `ai_meal_plan_items`

Stores AI-generated meals independently from the recipe-based `meal_plan` / `recipe_meal` tables. No `recipe_id` is required — AI meals carry their own nutrition fields (calories, proteins, fats, sodium, fiber, vitamins) and an ingredients JSONB array.

Migration SQL is included at `migrations/create_ai_meal_plan_items.sql` — run once in the Supabase SQL editor.

### Security fix — localhost bypass for IP block middleware

The `securityResponseService` IP block was triggering on `127.0.0.1` / `::1` during local development, returning 429 on every request after a previous failed login attempt. Loopback addresses now bypass the block check when `NODE_ENV !== 'production'`. Production behaviour is unchanged.

### Files changed

| File | Change |
|------|--------|
| `model/aiMealPlanItem.js` | New — `addAiMealItem`, `getAiMealItems`, `deleteAiMealItem` |
| `validators/aiMealSuggestionValidator.js` | New — validates meal_type, name, macros, ingredients |
| `controller/mealplanController.js` | Extended — 3 new handlers |
| `routes/mealplan.js` | Extended — `/ai-suggestion` route group |
| `index.yaml` | Extended — Swagger docs for all 3 endpoints |
| `services/securityEvents/securityResponseService.js` | Fixed — localhost bypass |
| `migrations/create_ai_meal_plan_items.sql` | New — table + index + RLS policy |

## Design Decisions

- **Separate table, not recipe-linked**: AI meals have no `recipe_id` in the database. Forcing them through the existing `meal_plan` + `recipe_meal` tables would require fabricating recipe records, polluting the recipes table. A dedicated table keeps the two flows independent.
- **Existing `POST /api/mealplan` untouched**: That endpoint is correctly restricted to nutritionist/admin and requires real recipe IDs. This PR adds alongside it, not instead of it.
- **All authenticated roles can save AI meals**: Users should be able to save their own AI suggestions without needing nutritionist privileges.