### PR TITLE
BE37: Internal Integration Audit Live Monitoring MVP

### DIFF
--- a/middleware/requestLogger.js
+++ b/middleware/requestLogger.js
@@ -6,6 +6,7 @@
  */
 
 const logger = require('../utils/logger');
+const { recordRequest } = require('../services/requestAuditService');
 
 /**
  * Generate unique request ID
@@ -69,6 +70,15 @@ const requestLoggingMiddleware = (req, res, next) => {
       ...(req.user ? { userId: req.user.id } : {}),
       contentLength: res.get('content-length'),
       ...(logLevel === 'error' ? { responseBody: data } : {})
+    });
+
+    recordRequest({
+      method,
+      path,
+      statusCode,
+      duration,
+      requestId,
+      userId: req.user?.userId || null,
     });
 
     // Call original send

--- a/routes/systemRoutes.js
+++ b/routes/systemRoutes.js
@@ -7,6 +7,28 @@ const authorizeRoles = require('../middleware/authorizeRoles');
 const {
   createBlockMiddleware,
 } = require('../services/securityEvents/securityResponseService');
+const { buildOverview } = require('../services/integrationAuditService');
+const {
+  getLiveOverview,
+  getLiveAuditState,
+} = require('../services/liveAuditService');
+
+function isLocalRequest(req) {
+  const ip = req.ip || req.connection?.remoteAddress || '';
+  const forwarded = req.headers['x-forwarded-for'] || '';
+  const candidates = [ip, forwarded]
+    .flatMap((value) => String(value || '').split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return candidates.some((value) =>
+    value === '127.0.0.1'
+    || value === '::1'
+    || value === '::ffff:127.0.0.1'
+    || value.startsWith('192.168.')
+    || value.startsWith('10.')
+  );
+}
 
 // Public health check (no auth required)
 router.get('/health', (req, res) => {
@@ -19,6 +41,64 @@ router.get('/health', (req, res) => {
     timestamp: new Date().toISOString()
   });
 });
+
+if (process.env.NODE_ENV !== 'production') {
+  router.get('/dev/live-audit/overview', async (req, res) => {
+    if (!isLocalRequest(req)) {
+      return res.status(403).json({
+        success: false,
+        error: 'This development endpoint is restricted to local requests.',
+        code: 'LOCAL_ONLY_ENDPOINT',
+      });
+    }
+
+    try {
+      const overview = await getLiveOverview();
+      res.status(200).json({
+        success: true,
+        data: overview,
+        meta: {
+          mode: 'dev-live',
+        },
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: 'Failed to build live integration audit overview',
+        code: 'LIVE_AUDIT_FAILED',
+        details: error.message,
+      });
+    }
+  });
+
+  router.get('/dev/integration-audit/overview', async (req, res) => {
+    if (!isLocalRequest(req)) {
+      return res.status(403).json({
+        success: false,
+        error: 'This development endpoint is restricted to local requests.',
+        code: 'LOCAL_ONLY_ENDPOINT',
+      });
+    }
+
+    try {
+      const overview = await buildOverview();
+      res.status(200).json({
+        success: true,
+        data: overview,
+        meta: {
+          mode: 'dev-local',
+        },
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: 'Failed to build integration audit overview',
+        code: 'INTEGRATION_AUDIT_FAILED',
+        details: error.message,
+      });
+    }
+  });
+}
 
 // All routes below require auth + admin role
 router.use(createBlockMiddleware());
@@ -92,6 +172,112 @@ router.get('/integrity-check', (req, res) => {
 if (process.env.NODE_ENV !== 'production') {
   router.use('/test-error', testErrorRouter);
 }
+
+router.get('/integration-audit/overview', async (req, res) => {
+  try {
+    const overview = await buildOverview();
+    res.status(200).json({
+      success: true,
+      data: overview,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to build integration audit overview',
+      code: 'INTEGRATION_AUDIT_FAILED',
+      details: process.env.NODE_ENV === 'production' ? undefined : error.message,
+    });
+  }
+});
+
+router.get('/live-audit/overview', async (req, res) => {
+  try {
+    const overview = await getLiveOverview();
+    res.status(200).json({
+      success: true,
+      data: overview,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to build live integration audit overview',
+      code: 'LIVE_AUDIT_FAILED',
+      details: process.env.NODE_ENV === 'production' ? undefined : error.message,
+    });
+  }
+});
+
+router.post('/live-audit/run', async (req, res) => {
+  try {
+    const overview = await getLiveOverview({ force: true });
+    res.status(200).json({
+      success: true,
+      data: overview,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to refresh live integration audit overview',
+      code: 'LIVE_AUDIT_REFRESH_FAILED',
+      details: process.env.NODE_ENV === 'production' ? undefined : error.message,
+    });
+  }
+});
+
+router.get('/live-audit/state', async (req, res) => {
+  try {
+    res.status(200).json({
+      success: true,
+      data: getLiveAuditState(),
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to load live audit state',
+      code: 'LIVE_AUDIT_STATE_FAILED',
+      details: process.env.NODE_ENV === 'production' ? undefined : error.message,
+    });
+  }
+});
+
+router.get('/integration-audit/routes', async (req, res) => {
+  try {
+    const overview = await buildOverview();
+    res.status(200).json({
+      success: true,
+      data: {
+        routeAudit: overview.routeAudit,
+        unusedRoutes: overview.unusedRoutes,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to load route audit data',
+      code: 'INTEGRATION_AUDIT_FAILED',
+      details: process.env.NODE_ENV === 'production' ? undefined : error.message,
+    });
+  }
+});
+
+router.get('/integration-audit/errors', async (req, res) => {
+  try {
+    const overview = await buildOverview();
+    res.status(200).json({
+      success: true,
+      data: {
+        recentErrors: overview.recentErrors,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to load recent errors',
+      code: 'INTEGRATION_AUDIT_FAILED',
+      details: process.env.NODE_ENV === 'production' ? undefined : error.message,
+    });
+  }
+});
 
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ const rateLimit = require('express-rate-limit');
 const uploadRoutes = require('./routes/uploadRoutes');
 const systemRoutes = require('./routes/systemRoutes');
 const { metricsMiddleware, metricsEndpoint } = require('./Monitor_&_Logging/metrics');
+const { startScheduler: startLiveAuditScheduler } = require('./services/liveAuditService');
 
 const FRONTEND_ORIGIN = 'http://localhost:3000';
 
@@ -42,6 +43,7 @@ console.log('   HTTP_PORT:', process.env.HTTP_PORT || process.env.PORT || '80 (d
 console.log('');
 
 const app = express();
+startLiveAuditScheduler();
 const HTTPS_PORT = Number(process.env.HTTPS_PORT) || 443;
 const HTTP_PORT = Number(process.env.HTTP_PORT || process.env.PORT) || 80;
 const tlsKeyPath = process.env.TLS_KEY_PATH || path.join(__dirname, 'certs', 'local-key.pem');
@@ -282,4 +284,3 @@ activeServer.listen(activePort, async () => {
     exec(`start ${proto}://localhost:${activePort}/api-docs`);
   }
 });
-

--- a/services/integrationAuditService.js
+++ b/services/integrationAuditService.js
@@ -1,0 +1,445 @@
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const path = require('path');
+const { routeGroups } = require('../routes/routeGroups');
+const aiServiceMonitor = require('./aiServiceMonitor');
+const errorLogService = require('./errorLogService');
+const { getSnapshot } = require('./requestAuditService');
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '..', '..');
+const API_ROOT = path.join(WORKSPACE_ROOT, 'Nutrihelp-api');
+
+const REPOSITORY_CANDIDATES = {
+  web: ['Nutrihelp-web'],
+  mobile: ['Nutrihelp-Mobile', 'NutriHelp-Mobile', 'NutriHelp-App-2026'],
+  api: ['Nutrihelp-api'],
+  ai: ['Nutrihelp-ai', 'NutriHelp-AI', 'NutriHelp AI', 'Nutrihelp-AI'],
+};
+
+function fileExists(targetPath) {
+  try {
+    return fs.existsSync(targetPath);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function detectRepositoryPath(candidateNames = []) {
+  for (const candidate of candidateNames) {
+    const repoPath = path.join(WORKSPACE_ROOT, candidate);
+    if (fileExists(repoPath)) {
+      return repoPath;
+    }
+  }
+  return null;
+}
+
+function buildRepositoryState() {
+  return Object.entries(REPOSITORY_CANDIDATES).reduce((accumulator, [key, candidates]) => {
+    const repoPath = detectRepositoryPath(candidates);
+    accumulator[key] = {
+      key,
+      available: Boolean(repoPath),
+      path: repoPath,
+      name: repoPath ? path.basename(repoPath) : candidates[0],
+    };
+    return accumulator;
+  }, {});
+}
+
+function probeUrl(url, timeoutMs = 1200) {
+  return new Promise((resolve) => {
+    if (!url) {
+      resolve({ ok: false, statusCode: null, error: 'missing-url' });
+      return;
+    }
+
+    const client = url.startsWith('https://') ? https : http;
+    const request = client.request(
+      url,
+      { method: 'GET', timeout: timeoutMs },
+      (response) => {
+        response.resume();
+        resolve({
+          ok: response.statusCode >= 200 && response.statusCode < 500,
+          statusCode: response.statusCode,
+          error: null,
+        });
+      }
+    );
+
+    request.on('timeout', () => {
+      request.destroy(new Error('timeout'));
+    });
+
+    request.on('error', (error) => {
+      resolve({ ok: false, statusCode: null, error: error.code || error.message || 'request-failed' });
+    });
+
+    request.end();
+  });
+}
+
+function buildRepositoryStatus({ state, status, runtimeUrl = null, note = null, repoType = null, runtimeReachable = null }) {
+  return {
+    ...state,
+    repoType: repoType || state.key,
+    status,
+    runtimeUrl,
+    runtimeReachable,
+    note,
+  };
+}
+
+async function enrichRepositoryState(repositories) {
+  const results = {};
+  const webRuntimeUrl = 'http://127.0.0.1:3000';
+  const aiRuntimeUrl = 'http://127.0.0.1:8000/ai-model/chatbot/chat';
+
+  if (!repositories.api.available) {
+    results.api = buildRepositoryStatus({
+      state: repositories.api,
+      status: 'not-loaded',
+      note: 'API repository is not present in the current workspace.',
+    });
+  } else {
+    results.api = buildRepositoryStatus({
+      state: repositories.api,
+      status: 'running',
+      runtimeUrl: 'http://127.0.0.1:8081/api',
+      runtimeReachable: true,
+      note: 'Current dashboard data is being served by this running API process.',
+    });
+  }
+
+  if (!repositories.web.available) {
+    results.web = buildRepositoryStatus({
+      state: repositories.web,
+      status: 'not-loaded',
+      note: 'Frontend repository is not present in the current workspace.',
+    });
+  } else {
+    const webProbe = await probeUrl(webRuntimeUrl);
+    results.web = buildRepositoryStatus({
+      state: repositories.web,
+      status: webProbe.ok ? 'running' : 'code-only',
+      runtimeUrl: webRuntimeUrl,
+      runtimeReachable: webProbe.ok,
+      note: webProbe.ok
+        ? 'Frontend source is loaded and a local dev server is responding.'
+        : 'Frontend source is available, but no local web runtime was detected on port 3000.',
+    });
+  }
+
+  if (!repositories.mobile.available) {
+    results.mobile = buildRepositoryStatus({
+      state: repositories.mobile,
+      status: 'not-loaded',
+      note: 'Mobile repository is not present in the current workspace.',
+    });
+  } else {
+    results.mobile = buildRepositoryStatus({
+      state: repositories.mobile,
+      status: 'code-only',
+      note: 'Mobile source is available for route auditing, but no live Expo/device session is being tracked by this tool.',
+    });
+  }
+
+  if (!repositories.ai.available) {
+    results.ai = buildRepositoryStatus({
+      state: repositories.ai,
+      status: 'not-loaded',
+      runtimeUrl: aiRuntimeUrl,
+      runtimeReachable: false,
+      note: 'AI repository is not present in the current workspace, so only route references can be inferred from web/api code.',
+    });
+  } else {
+    const aiProbe = await probeUrl(aiRuntimeUrl);
+    results.ai = buildRepositoryStatus({
+      state: repositories.ai,
+      status: aiProbe.ok ? 'running' : 'not-running',
+      runtimeUrl: aiRuntimeUrl,
+      runtimeReachable: aiProbe.ok,
+      note: aiProbe.ok
+        ? 'AI repository is loaded and the local AI runtime responded on port 8000.'
+        : 'AI source is loaded, but no responding local runtime was detected on port 8000.',
+    });
+  }
+
+  return results;
+}
+
+function extractImportMap(appSource) {
+  const importMap = {};
+  const importRegex = /^import\s+([A-Za-z0-9_{}\s,*]+)\s+from\s+["'](.+)["'];?$/gm;
+  let match;
+
+  while ((match = importRegex.exec(appSource)) !== null) {
+    const imported = match[1].trim();
+    const importPath = match[2];
+
+    if (!importPath.startsWith('.')) continue;
+
+    if (imported.startsWith('{')) {
+      continue;
+    }
+
+    importMap[imported] = importPath;
+  }
+
+  return importMap;
+}
+
+function extractWebRoutes(appSource) {
+  const routeRegex = /<Route\s+[^>]*path=["']([^"']+)["'][\s\S]*?element=\{[\s\S]*?<([A-Z][A-Za-z0-9_]*)\s*\/>[\s\S]*?\}\s*\/>/g;
+  const routes = [];
+  let match;
+
+  while ((match = routeRegex.exec(appSource)) !== null) {
+    routes.push({
+      path: match[1],
+      componentName: match[2],
+    });
+  }
+
+  return routes;
+}
+
+function resolveModulePath(fromFile, importPath) {
+  const basePath = path.resolve(path.dirname(fromFile), importPath);
+  const candidates = [
+    basePath,
+    `${basePath}.js`,
+    `${basePath}.jsx`,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    path.join(basePath, 'index.js'),
+    path.join(basePath, 'index.jsx'),
+  ];
+
+  return candidates.find((candidate) => fileExists(candidate)) || null;
+}
+
+function extractRelativeImports(fileSource) {
+  const imports = [];
+  const importRegex = /^import\s+.+?\s+from\s+["'](.+)["'];?$/gm;
+  let match;
+  while ((match = importRegex.exec(fileSource)) !== null) {
+    if (match[1].startsWith('.')) imports.push(match[1]);
+  }
+  return imports;
+}
+
+function extractApiRefs(fileSource) {
+  const apiMatches = fileSource.match(/\/api\/[A-Za-z0-9/_-]+/g) || [];
+  return [...new Set(apiMatches)];
+}
+
+function extractAiRefs(fileSource) {
+  const aiMatches = fileSource.match(/\/ai-model\/[A-Za-z0-9/_-]+/g) || [];
+  return [...new Set(aiMatches)];
+}
+
+function collectIntegrationRefs(filePath, visited = new Set(), depth = 0) {
+  if (!filePath || visited.has(filePath) || depth > 2 || !fileExists(filePath)) {
+    return { apiRefs: [], aiRefs: [] };
+  }
+
+  visited.add(filePath);
+  const source = readText(filePath);
+  const apiRefs = new Set(extractApiRefs(source));
+  const aiRefs = new Set(extractAiRefs(source));
+
+  extractRelativeImports(source).forEach((importPath) => {
+    const resolved = resolveModulePath(filePath, importPath);
+    if (!resolved) return;
+
+    const nested = collectIntegrationRefs(resolved, visited, depth + 1);
+    nested.apiRefs.forEach((item) => apiRefs.add(item));
+    nested.aiRefs.forEach((item) => aiRefs.add(item));
+  });
+
+  return {
+    apiRefs: [...apiRefs],
+    aiRefs: [...aiRefs],
+  };
+}
+
+function getBackendRoutes() {
+  const mounted = routeGroups.flatMap((group) =>
+    group.routes.map(([mountPath, modulePath]) => ({
+      group: group.name,
+      mountPath,
+      modulePath,
+    }))
+  );
+
+  mounted.push(
+    { group: 'system', mountPath: '/api/system', modulePath: './systemRoutes' },
+    { group: 'platform', mountPath: '/api/metrics', modulePath: 'server' },
+    { group: 'platform', mountPath: '/api/health', modulePath: 'server' }
+  );
+
+  return mounted;
+}
+
+function normalizeBackendMatch(apiRef, backendRoutes) {
+  return backendRoutes.find((route) => apiRef === route.mountPath || apiRef.startsWith(route.mountPath));
+}
+
+function buildWebAudit(repositories, backendRoutes) {
+  const webRepo = repositories.web;
+  if (!webRepo.available) {
+    return {
+      routes: [],
+      unusedBackendRoutes: backendRoutes,
+      emptyFrontendRoutes: [],
+    };
+  }
+
+  const appPath = path.join(webRepo.path, 'src', 'App.js');
+  if (!fileExists(appPath)) {
+    return {
+      routes: [],
+      unusedBackendRoutes: backendRoutes,
+      emptyFrontendRoutes: [],
+    };
+  }
+
+  const appSource = readText(appPath);
+  const importMap = extractImportMap(appSource);
+  const webRoutes = extractWebRoutes(appSource).map((route) => {
+    const importPath = importMap[route.componentName];
+    const componentPath = importPath ? resolveModulePath(appPath, importPath) : null;
+    const refs = collectIntegrationRefs(componentPath);
+    const matchedBackendRoutes = refs.apiRefs
+      .map((apiRef) => normalizeBackendMatch(apiRef, backendRoutes))
+      .filter(Boolean);
+    const unmatchedBackendRefs = refs.apiRefs.filter(
+      (apiRef) => !normalizeBackendMatch(apiRef, backendRoutes)
+    );
+
+    let status = 'connected';
+    if (refs.apiRefs.length === 0 && refs.aiRefs.length === 0) {
+      status = 'empty-or-ui-only';
+    } else if (unmatchedBackendRefs.length > 0) {
+      status = 'backend-mismatch';
+    }
+
+    return {
+      frontendRoute: route.path,
+      componentName: route.componentName,
+      componentFile: componentPath
+        ? path.relative(webRepo.path, componentPath)
+        : importPath || null,
+      backendApis: refs.apiRefs,
+      backendRouteMatches: matchedBackendRoutes.map((match) => match.mountPath),
+      aiServices: refs.aiRefs,
+      status,
+      notes:
+        status === 'backend-mismatch'
+          ? `Unmatched API refs: ${unmatchedBackendRefs.join(', ')}`
+          : status === 'empty-or-ui-only'
+            ? 'No direct API or AI integrations detected in component/import graph.'
+            : refs.aiRefs.length > 0 && refs.apiRefs.length === 0
+              ? 'Direct AI integration detected. This frontend flow connects to NutriHelp-AI without going through Nutrihelp-api.'
+            : null,
+    };
+  });
+
+  const referencedBackendRoutes = new Set(
+    webRoutes.flatMap((route) => route.backendRouteMatches)
+  );
+
+  return {
+    routes: webRoutes,
+    unusedBackendRoutes: backendRoutes.filter(
+      (route) => !referencedBackendRoutes.has(route.mountPath)
+    ),
+    emptyFrontendRoutes: webRoutes.filter((route) => route.status === 'empty-or-ui-only'),
+  };
+}
+
+function getRecentErrors(limit = 15) {
+  const logPath = path.join(API_ROOT, 'logs', 'error_log.jsonl');
+  if (!fileExists(logPath)) {
+    return [];
+  }
+
+  const raw = readText(logPath).trim();
+  if (!raw) return [];
+
+  return raw
+    .split('\n')
+    .slice(-limit)
+    .reverse()
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch (_error) {
+        return { message: line, timestamp: null, category: 'unknown', type: 'unknown' };
+      }
+    });
+}
+
+async function buildOverview() {
+  const repositories = buildRepositoryState();
+  const repositoryStatus = await enrichRepositoryState(repositories);
+  const backendRoutes = getBackendRoutes();
+  const webAudit = buildWebAudit(repositoryStatus, backendRoutes);
+  const runtime = getSnapshot();
+  const aiStats = aiServiceMonitor.getStats();
+  const errorHealth = await errorLogService.healthCheck();
+  const recentErrors = getRecentErrors();
+
+  const chatbotApiCalls = runtime.requests.byPath
+    .filter((entry) => entry.path.includes('/chatbot'))
+    .reduce((sum, entry) => sum + entry.total, 0);
+
+  const chatbotAiCalls = Object.entries(aiStats)
+    .filter(([serviceName]) => serviceName.toLowerCase().includes('chatbot'))
+    .reduce((sum, [, entry]) => sum + (entry.calls || 0), 0);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    repositories: Object.values(repositoryStatus),
+    summary: {
+      totalFrontendRoutes: webAudit.routes.length,
+      totalBackendRoutes: backendRoutes.length,
+      connectedRoutes: webAudit.routes.filter((route) => route.status === 'connected').length,
+      emptyFrontendRoutes: webAudit.emptyFrontendRoutes.length,
+      unusedBackendRoutes: webAudit.unusedBackendRoutes.length,
+      chatbotRequests: chatbotApiCalls,
+      chatbotAiCalls,
+      recentErrorCount: recentErrors.length,
+      repositoriesNotLoaded: Object.values(repositoryStatus).filter((repo) => repo.status === 'not-loaded').length,
+      repositoriesCodeOnly: Object.values(repositoryStatus).filter((repo) => repo.status === 'code-only').length,
+      repositoriesNotRunning: Object.values(repositoryStatus).filter((repo) => repo.status === 'not-running').length,
+      repositoriesRunning: Object.values(repositoryStatus).filter((repo) => repo.status === 'running').length,
+    },
+    health: {
+      api: {
+        requestAuditStartedAt: runtime.startedAt,
+        runtimeRequestCount: runtime.requests.total,
+      },
+      errorLogging: errorHealth,
+      aiServices: aiStats,
+    },
+    routeAudit: webAudit.routes,
+    unusedRoutes: {
+      frontend: webAudit.emptyFrontendRoutes,
+      backend: webAudit.unusedBackendRoutes,
+    },
+    requestOverview: runtime.requests,
+    recentErrors,
+  };
+}
+
+module.exports = {
+  buildOverview,
+};

--- a/services/liveAuditService.js
+++ b/services/liveAuditService.js
@@ -1,0 +1,131 @@
+const { buildOverview } = require('./integrationAuditService');
+
+const DEFAULT_REFRESH_MS = Number(process.env.LIVE_AUDIT_REFRESH_MS || 30000);
+
+const state = {
+  startedAt: new Date().toISOString(),
+  refreshIntervalMs: DEFAULT_REFRESH_MS,
+  schedulerStarted: false,
+  timer: null,
+  snapshot: null,
+  inFlight: null,
+  lastRunAt: null,
+  nextRunAt: null,
+  lastError: null,
+};
+
+function buildMeta(trigger = 'snapshot') {
+  return {
+    mode: 'live',
+    trigger,
+    startedAt: state.startedAt,
+    refreshIntervalMs: state.refreshIntervalMs,
+    lastRunAt: state.lastRunAt,
+    nextRunAt: state.nextRunAt,
+    lastError: state.lastError,
+  };
+}
+
+async function refreshSnapshot(trigger = 'scheduler') {
+  if (state.inFlight) {
+    return state.inFlight;
+  }
+
+  state.inFlight = (async () => {
+    try {
+      const overview = await buildOverview();
+      const checkedAt = new Date().toISOString();
+
+      state.lastRunAt = checkedAt;
+      state.nextRunAt = new Date(Date.now() + state.refreshIntervalMs).toISOString();
+      state.lastError = null;
+      state.snapshot = {
+        ...overview,
+        generatedAt: checkedAt,
+        live: buildMeta(trigger),
+      };
+
+      return state.snapshot;
+    } catch (error) {
+      state.lastError = {
+        message: error.message,
+        at: new Date().toISOString(),
+      };
+
+      if (state.snapshot) {
+        state.snapshot = {
+          ...state.snapshot,
+          live: buildMeta('stale-fallback'),
+        };
+        return state.snapshot;
+      }
+
+      throw error;
+    } finally {
+      state.inFlight = null;
+    }
+  })();
+
+  return state.inFlight;
+}
+
+function startScheduler() {
+  if (state.schedulerStarted) {
+    return;
+  }
+
+  state.schedulerStarted = true;
+  state.nextRunAt = new Date(Date.now() + state.refreshIntervalMs).toISOString();
+
+  refreshSnapshot('bootstrap').catch(() => {
+    // Errors are surfaced through the live endpoint metadata.
+  });
+
+  state.timer = setInterval(() => {
+    refreshSnapshot('scheduler').catch(() => {
+      // Keep the scheduler alive even if one run fails.
+    });
+  }, state.refreshIntervalMs);
+
+  if (typeof state.timer.unref === 'function') {
+    state.timer.unref();
+  }
+}
+
+async function getLiveOverview(options = {}) {
+  const { force = false } = options;
+  startScheduler();
+
+  if (force) {
+    return refreshSnapshot('manual-refresh');
+  }
+
+  if (state.snapshot) {
+    return {
+      ...state.snapshot,
+      live: buildMeta('snapshot'),
+    };
+  }
+
+  return refreshSnapshot('initial-load');
+}
+
+function getLiveAuditState() {
+  return {
+    startedAt: state.startedAt,
+    refreshIntervalMs: state.refreshIntervalMs,
+    schedulerStarted: state.schedulerStarted,
+    lastRunAt: state.lastRunAt,
+    nextRunAt: state.nextRunAt,
+    lastError: state.lastError,
+    hasSnapshot: Boolean(state.snapshot),
+  };
+}
+
+module.exports = {
+  DEFAULT_REFRESH_MS,
+  getLiveOverview,
+  getLiveAuditState,
+  refreshSnapshot,
+  startScheduler,
+};

--- a/services/requestAuditService.js
+++ b/services/requestAuditService.js
@@ -1,0 +1,90 @@
+const MAX_RECENT_REQUESTS = 200;
+
+const runtime = {
+  startedAt: new Date().toISOString(),
+  requests: {
+    total: 0,
+    byPath: {},
+    byStatusFamily: {
+      success: 0,
+      clientError: 0,
+      serverError: 0,
+    },
+    recent: [],
+  },
+};
+
+function normalizePath(pathname) {
+  return String(pathname || '').trim() || 'unknown';
+}
+
+function classifyStatus(statusCode) {
+  const code = Number(statusCode) || 0;
+  if (code >= 500) return 'serverError';
+  if (code >= 400) return 'clientError';
+  return 'success';
+}
+
+function recordRequest({
+  method,
+  path,
+  statusCode,
+  duration,
+  requestId,
+  userId = null,
+} = {}) {
+  const normalizedPath = normalizePath(path);
+  const normalizedMethod = String(method || 'GET').toUpperCase();
+  const statusFamily = classifyStatus(statusCode);
+
+  runtime.requests.total += 1;
+  runtime.requests.byStatusFamily[statusFamily] += 1;
+
+  if (!runtime.requests.byPath[normalizedPath]) {
+    runtime.requests.byPath[normalizedPath] = {
+      path: normalizedPath,
+      total: 0,
+      methods: {},
+      lastStatusCode: null,
+      lastCalledAt: null,
+    };
+  }
+
+  const pathBucket = runtime.requests.byPath[normalizedPath];
+  pathBucket.total += 1;
+  pathBucket.lastStatusCode = Number(statusCode) || null;
+  pathBucket.lastCalledAt = new Date().toISOString();
+  pathBucket.methods[normalizedMethod] = (pathBucket.methods[normalizedMethod] || 0) + 1;
+
+  runtime.requests.recent.unshift({
+    method: normalizedMethod,
+    path: normalizedPath,
+    statusCode: Number(statusCode) || null,
+    duration: Number(duration) || 0,
+    requestId: requestId || null,
+    userId: userId || null,
+    at: new Date().toISOString(),
+  });
+
+  if (runtime.requests.recent.length > MAX_RECENT_REQUESTS) {
+    runtime.requests.recent.length = MAX_RECENT_REQUESTS;
+  }
+}
+
+function getSnapshot() {
+  return {
+    startedAt: runtime.startedAt,
+    requests: {
+      total: runtime.requests.total,
+      byStatusFamily: { ...runtime.requests.byStatusFamily },
+      byPath: Object.values(runtime.requests.byPath)
+        .sort((left, right) => right.total - left.total),
+      recent: runtime.requests.recent.slice(0, 50),
+    },
+  };
+}
+
+module.exports = {
+  recordRequest,
+  getSnapshot,
+};


### PR DESCRIPTION
## Summary
Introduces a live internal integration audit service in `Nutrihelp-api` to improve visibility across local runtime integrations. This adds repository/runtime detection, route audit aggregation, request activity tracking, and live audit endpoints that support the internal dashboard in `Nutrihelp-web`. The API now exposes both development-local and authenticated live audit endpoints, and starts a lightweight background scheduler to refresh audit snapshots automatically.

## Why it needed
We are currently operating across multiple repositories, and it has become difficult to quickly understand which frontend routes connect to backend APIs and AI services, which systems are actually running, and where integration mismatches exist. The previous local audit flow required manual refresh logic and did not provide a live snapshot model. This change centralizes that visibility in `Nutrihelp-api`, making it easier for the team to debug broken connections, monitor route coverage, and distinguish between running, code-only, not-loaded, and not-running repositories.

## Testing
- Verified backend syntax with:
  - `node -c services/liveAuditService.js`
  - `node -c services/integrationAuditService.js`
  - `node -c routes/systemRoutes.js`
  - `node -c server.js`
- Restarted `Nutrihelp-api` and confirmed live audit endpoints respond successfully
- Confirmed development live endpoint returns repository and route audit data:
  - `GET /api/system/dev/live-audit/overview`
- Verified live repository status detection reflects local runtime state:
  - `Nutrihelp-api` as `running`
  - `Nutrihelp-web` as `running`
  - `NutriHelp-AI` as `running`
  - `NutriHelp-App-2026` as `code-only`
- Confirmed direct frontend-to-AI integrations are reported as `connected` with explanatory notes instead of being treated as warning-only states