### PR TITLE
feat: sync NutriHelp-AI routers to Nutrihelp-api (6 remaining routes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 build/
 test-results/
 /data
+!data/meal_library.json
 server.pid
 server.log
 *.bak

--- a/data/meal_library.json
+++ b/data/meal_library.json
@@ -1,0 +1,2973 @@
+[
+  {
+    "id": "a1",
+    "name": "Oats with berries and chia",
+    "meal_type": "breakfast",
+    "calories": 350,
+    "protein_g": 12,
+    "carbs_g": 51,
+    "fat_g": 10,
+    "fibre_g": 11,
+    "sodium_mg": 120,
+    "tags": [
+      "low_sugar",
+      "high_fibre",
+      "vegetarian",
+      "soft_food",
+      "cost_low",
+      "low_gi"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "whole_grain",
+      "breakfast_bowl",
+      "plant_based"
+    ],
+    "micronutrients": {
+      "iron_mg": 3.2,
+      "magnesium_mg": 118,
+      "potassium_mg": 390
+    },
+    "vitamins": [
+      "vitamin_b1",
+      "vitamin_b6",
+      "vitamin_e"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium",
+      "zinc"
+    ],
+    "cuisine": "Global Healthy",
+    "region": "Global",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a2",
+    "name": "Scrambled eggs on toast",
+    "meal_type": "breakfast",
+    "calories": 380,
+    "protein_g": 21,
+    "carbs_g": 28,
+    "fat_g": 20,
+    "fibre_g": 4,
+    "sodium_mg": 460,
+    "tags": [
+      "high_protein",
+      "contains_egg",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_low"
+    ],
+    "allergens": [
+      "egg",
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "egg_based",
+      "toast",
+      "breakfast"
+    ],
+    "micronutrients": {
+      "choline_mg": 290,
+      "selenium_mcg": 26,
+      "calcium_mg": 110
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "vitamin_d",
+      "folate"
+    ],
+    "minerals": [
+      "selenium",
+      "phosphorus",
+      "calcium"
+    ],
+    "cuisine": "Western",
+    "region": "European",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a3",
+    "name": "Grilled chicken salad",
+    "meal_type": "lunch",
+    "calories": 450,
+    "protein_g": 38,
+    "carbs_g": 18,
+    "fat_g": 20,
+    "fibre_g": 6,
+    "sodium_mg": 360,
+    "tags": [
+      "low_fat",
+      "low_salt",
+      "high_protein",
+      "cost_medium",
+      "low_carb"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "salad",
+      "lean_protein"
+    ],
+    "micronutrients": {
+      "vitamin_k_mcg": 120,
+      "potassium_mg": 620,
+      "zinc_mg": 2.1
+    },
+    "vitamins": [
+      "vitamin_a",
+      "vitamin_k",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "potassium",
+      "zinc",
+      "phosphorus"
+    ],
+    "cuisine": "Western",
+    "region": "European",
+    "seasonal_tags": [
+      "spring",
+      "summer"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a4",
+    "name": "Vegetable stir-fry with tofu and rice",
+    "meal_type": "lunch",
+    "calories": 500,
+    "protein_g": 20,
+    "carbs_g": 58,
+    "fat_g": 18,
+    "fibre_g": 8,
+    "sodium_mg": 410,
+    "tags": [
+      "soft_food",
+      "low_fat",
+      "low_salt",
+      "asian",
+      "contains_soy",
+      "vegetarian",
+      "cost_low",
+      "high_fibre"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "stir_fry",
+      "plant_protein"
+    ],
+    "micronutrients": {
+      "calcium_mg": 240,
+      "iron_mg": 3.4,
+      "magnesium_mg": 96
+    },
+    "vitamins": [
+      "vitamin_c",
+      "folate",
+      "vitamin_k"
+    ],
+    "minerals": [
+      "calcium",
+      "iron",
+      "magnesium"
+    ],
+    "cuisine": "Chinese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a5",
+    "name": "Baked salmon with steamed veggies",
+    "meal_type": "dinner",
+    "calories": 520,
+    "protein_g": 40,
+    "carbs_g": 22,
+    "fat_g": 28,
+    "fibre_g": 7,
+    "sodium_mg": 310,
+    "tags": [
+      "low_sugar",
+      "high_protein",
+      "low_salt",
+      "contains_fish",
+      "cost_high",
+      "omega3_rich",
+      "heart_healthy"
+    ],
+    "allergens": [
+      "fish"
+    ],
+    "food_categories": [
+      "seafood",
+      "lean_protein",
+      "dinner_plate"
+    ],
+    "micronutrients": {
+      "vitamin_d_iu": 540,
+      "selenium_mcg": 42,
+      "potassium_mg": 780
+    },
+    "vitamins": [
+      "vitamin_d",
+      "vitamin_b12",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "selenium",
+      "potassium",
+      "phosphorus"
+    ],
+    "cuisine": "Mediterranean",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "spring",
+      "summer"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a6",
+    "name": "Lentil soup with soft bread",
+    "meal_type": "dinner",
+    "calories": 480,
+    "protein_g": 22,
+    "carbs_g": 66,
+    "fat_g": 12,
+    "fibre_g": 13,
+    "sodium_mg": 390,
+    "tags": [
+      "vegetarian",
+      "soft_food",
+      "low_fat",
+      "low_salt",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_low",
+      "high_fibre"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "soup",
+      "legume",
+      "comfort_food"
+    ],
+    "micronutrients": {
+      "iron_mg": 5.8,
+      "folate_mcg": 230,
+      "magnesium_mg": 88
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_b1",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium",
+      "potassium"
+    ],
+    "cuisine": "Middle Eastern",
+    "region": "Middle Eastern",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a7",
+    "name": "Apple slices with yoghurt",
+    "meal_type": "snack",
+    "calories": 150,
+    "protein_g": 6,
+    "carbs_g": 24,
+    "fat_g": 3,
+    "fibre_g": 3,
+    "sodium_mg": 60,
+    "tags": [
+      "low_fat",
+      "contains_yoghurt",
+      "contains_dairy",
+      "contains_apple",
+      "cost_low",
+      "probiotic"
+    ],
+    "allergens": [
+      "dairy",
+      "apple"
+    ],
+    "food_categories": [
+      "snack",
+      "fruit",
+      "probiotic"
+    ],
+    "micronutrients": {
+      "calcium_mg": 190,
+      "vitamin_c_mg": 7.0,
+      "potassium_mg": 230
+    },
+    "vitamins": [
+      "vitamin_c",
+      "vitamin_b2"
+    ],
+    "minerals": [
+      "calcium",
+      "potassium"
+    ],
+    "cuisine": "Western",
+    "region": "Global",
+    "seasonal_tags": [
+      "summer",
+      "spring"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a8",
+    "name": "Unsalted mixed nuts",
+    "meal_type": "snack",
+    "calories": 200,
+    "protein_g": 7,
+    "carbs_g": 8,
+    "fat_g": 17,
+    "fibre_g": 3,
+    "sodium_mg": 5,
+    "tags": [
+      "contains_nuts",
+      "contains_tree_nut",
+      "low_sugar",
+      "cost_medium",
+      "heart_healthy"
+    ],
+    "allergens": [
+      "nuts",
+      "tree_nut"
+    ],
+    "food_categories": [
+      "snack",
+      "nuts",
+      "healthy_fat"
+    ],
+    "micronutrients": {
+      "magnesium_mg": 95,
+      "vitamin_e_mg": 5.5,
+      "zinc_mg": 1.2
+    },
+    "vitamins": [
+      "vitamin_e",
+      "vitamin_b1"
+    ],
+    "minerals": [
+      "magnesium",
+      "zinc",
+      "copper"
+    ],
+    "cuisine": "Global Healthy",
+    "region": "Global",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a9",
+    "name": "Sugary cereal with milk",
+    "meal_type": "breakfast",
+    "calories": 420,
+    "protein_g": 11,
+    "carbs_g": 67,
+    "fat_g": 9,
+    "fibre_g": 2,
+    "sodium_mg": 370,
+    "tags": [
+      "high_sugar",
+      "high_gi",
+      "refined_carb",
+      "contains_dairy",
+      "contains_milk",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_low"
+    ],
+    "allergens": [
+      "dairy",
+      "milk",
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "processed_breakfast",
+      "cereal"
+    ],
+    "micronutrients": {
+      "calcium_mg": 260,
+      "iron_mg": 4.2
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "vitamin_d"
+    ],
+    "minerals": [
+      "calcium",
+      "iron"
+    ],
+    "cuisine": "Western",
+    "region": "Global",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a10",
+    "name": "Wholegrain toast with avocado",
+    "meal_type": "breakfast",
+    "calories": 360,
+    "protein_g": 10,
+    "carbs_g": 38,
+    "fat_g": 18,
+    "fibre_g": 10,
+    "sodium_mg": 280,
+    "tags": [
+      "low_sugar",
+      "high_fibre",
+      "low_salt",
+      "vegetarian",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_medium",
+      "heart_healthy"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "toast",
+      "plant_based",
+      "healthy_fat"
+    ],
+    "micronutrients": {
+      "potassium_mg": 620,
+      "folate_mcg": 96,
+      "vitamin_e_mg": 2.4
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_e",
+      "vitamin_k"
+    ],
+    "minerals": [
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Mediterranean",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a11",
+    "name": "Chicken burger and fries",
+    "meal_type": "lunch",
+    "calories": 800,
+    "protein_g": 34,
+    "carbs_g": 78,
+    "fat_g": 38,
+    "fibre_g": 5,
+    "sodium_mg": 1250,
+    "tags": [
+      "high_fat",
+      "high_saturated_fat",
+      "fried",
+      "processed_meat",
+      "high_salt",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_medium"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "fast_food",
+      "fried"
+    ],
+    "micronutrients": {
+      "iron_mg": 3.9,
+      "potassium_mg": 740
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "niacin"
+    ],
+    "minerals": [
+      "sodium",
+      "iron"
+    ],
+    "cuisine": "Western",
+    "region": "North American",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a12",
+    "name": "Brown rice with grilled fish and veggies",
+    "meal_type": "lunch",
+    "calories": 520,
+    "protein_g": 36,
+    "carbs_g": 52,
+    "fat_g": 16,
+    "fibre_g": 8,
+    "sodium_mg": 340,
+    "tags": [
+      "low_sugar",
+      "low_gi",
+      "low_fat",
+      "low_salt",
+      "high_protein",
+      "contains_fish",
+      "cost_high",
+      "heart_healthy"
+    ],
+    "allergens": [
+      "fish"
+    ],
+    "food_categories": [
+      "rice_bowl",
+      "seafood",
+      "balanced_plate"
+    ],
+    "micronutrients": {
+      "selenium_mcg": 38,
+      "magnesium_mg": 95,
+      "potassium_mg": 810
+    },
+    "vitamins": [
+      "vitamin_d",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "selenium",
+      "magnesium",
+      "potassium"
+    ],
+    "cuisine": "Asian Fusion",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a13",
+    "name": "Instant noodles with seasoning packet",
+    "meal_type": "lunch",
+    "calories": 550,
+    "protein_g": 12,
+    "carbs_g": 67,
+    "fat_g": 24,
+    "fibre_g": 3,
+    "sodium_mg": 1650,
+    "tags": [
+      "high_salt",
+      "very_high_salt",
+      "refined_carb",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_low"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "processed_food",
+      "noodles"
+    ],
+    "micronutrients": {
+      "iron_mg": 2.4
+    },
+    "vitamins": [
+      "niacin"
+    ],
+    "minerals": [
+      "sodium"
+    ],
+    "cuisine": "Japanese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a14",
+    "name": "Beef stir-fry with vegetables and soy sauce",
+    "meal_type": "dinner",
+    "calories": 650,
+    "protein_g": 39,
+    "carbs_g": 36,
+    "fat_g": 31,
+    "fibre_g": 6,
+    "sodium_mg": 970,
+    "tags": [
+      "high_salt",
+      "soy_sauce_heavy",
+      "asian",
+      "high_protein",
+      "contains_soy",
+      "cost_high"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "stir_fry",
+      "red_meat"
+    ],
+    "micronutrients": {
+      "iron_mg": 4.8,
+      "zinc_mg": 5.3,
+      "vitamin_b12_mcg": 2.1
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "niacin"
+    ],
+    "minerals": [
+      "iron",
+      "zinc",
+      "sodium"
+    ],
+    "cuisine": "Chinese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a15",
+    "name": "Cheese pizza slice",
+    "meal_type": "dinner",
+    "calories": 780,
+    "protein_g": 29,
+    "carbs_g": 78,
+    "fat_g": 39,
+    "fibre_g": 4,
+    "sodium_mg": 1280,
+    "tags": [
+      "high_fat",
+      "high_saturated_fat",
+      "contains_dairy",
+      "contains_cheese",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_medium"
+    ],
+    "allergens": [
+      "dairy",
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "fast_food",
+      "pizza"
+    ],
+    "micronutrients": {
+      "calcium_mg": 380,
+      "iron_mg": 3.1
+    },
+    "vitamins": [
+      "vitamin_a",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "calcium",
+      "sodium"
+    ],
+    "cuisine": "Italian",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a16",
+    "name": "Donut and soft drink",
+    "meal_type": "snack",
+    "calories": 600,
+    "protein_g": 6,
+    "carbs_g": 90,
+    "fat_g": 24,
+    "fibre_g": 2,
+    "sodium_mg": 430,
+    "tags": [
+      "dessert",
+      "high_sugar",
+      "added_sugar",
+      "refined_carb",
+      "sugary_drink",
+      "high_fat",
+      "contains_gluten",
+      "contains_wheat",
+      "cost_low"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "dessert",
+      "processed_snack"
+    ],
+    "micronutrients": {
+      "iron_mg": 1.8
+    },
+    "vitamins": [],
+    "minerals": [
+      "sodium"
+    ],
+    "cuisine": "Western",
+    "region": "Global",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a17",
+    "name": "Fresh fruit salad",
+    "meal_type": "snack",
+    "calories": 180,
+    "protein_g": 3,
+    "carbs_g": 42,
+    "fat_g": 1,
+    "fibre_g": 6,
+    "sodium_mg": 15,
+    "tags": [
+      "low_sugar",
+      "low_fat",
+      "low_salt",
+      "vegetarian",
+      "cost_low",
+      "contains_fruit",
+      "contains_apple",
+      "contains_strawberry",
+      "contains_kiwi",
+      "high_fibre"
+    ],
+    "allergens": [
+      "fruit",
+      "apple",
+      "strawberry",
+      "kiwi"
+    ],
+    "food_categories": [
+      "snack",
+      "fruit",
+      "plant_based"
+    ],
+    "micronutrients": {
+      "vitamin_c_mg": 62,
+      "potassium_mg": 430
+    },
+    "vitamins": [
+      "vitamin_c",
+      "folate"
+    ],
+    "minerals": [
+      "potassium"
+    ],
+    "cuisine": "Global Healthy",
+    "region": "Global",
+    "seasonal_tags": [
+      "summer",
+      "spring"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a18",
+    "name": "Low-fat yoghurt with nuts",
+    "meal_type": "snack",
+    "calories": 220,
+    "protein_g": 11,
+    "carbs_g": 17,
+    "fat_g": 12,
+    "fibre_g": 2,
+    "sodium_mg": 85,
+    "tags": [
+      "low_fat",
+      "contains_yoghurt",
+      "contains_dairy",
+      "contains_nuts",
+      "contains_tree_nut",
+      "cost_medium",
+      "probiotic"
+    ],
+    "allergens": [
+      "dairy",
+      "nuts",
+      "tree_nut"
+    ],
+    "food_categories": [
+      "snack",
+      "probiotic",
+      "healthy_fat"
+    ],
+    "micronutrients": {
+      "calcium_mg": 260,
+      "magnesium_mg": 52
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "vitamin_d"
+    ],
+    "minerals": [
+      "calcium",
+      "magnesium"
+    ],
+    "cuisine": "Mediterranean",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a19",
+    "name": "Greek yoghurt parfait with walnuts",
+    "meal_type": "breakfast",
+    "calories": 340,
+    "protein_g": 20,
+    "carbs_g": 28,
+    "fat_g": 14,
+    "fibre_g": 4,
+    "sodium_mg": 95,
+    "tags": [
+      "high_protein",
+      "contains_dairy",
+      "contains_yoghurt",
+      "contains_nuts",
+      "contains_tree_nut",
+      "cost_medium",
+      "probiotic"
+    ],
+    "allergens": [
+      "dairy",
+      "nuts",
+      "tree_nut"
+    ],
+    "food_categories": [
+      "breakfast",
+      "probiotic",
+      "high_protein"
+    ],
+    "micronutrients": {
+      "calcium_mg": 280,
+      "omega3_g": 1.9,
+      "manganese_mg": 1.4
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "vitamin_d"
+    ],
+    "minerals": [
+      "calcium",
+      "manganese",
+      "phosphorus"
+    ],
+    "cuisine": "Greek",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a20",
+    "name": "Spinach mushroom omelette",
+    "meal_type": "breakfast",
+    "calories": 320,
+    "protein_g": 24,
+    "carbs_g": 10,
+    "fat_g": 20,
+    "fibre_g": 3,
+    "sodium_mg": 320,
+    "tags": [
+      "high_protein",
+      "contains_egg",
+      "low_carb",
+      "soft_food",
+      "cost_medium"
+    ],
+    "allergens": [
+      "egg"
+    ],
+    "food_categories": [
+      "egg_based",
+      "breakfast",
+      "low_carb"
+    ],
+    "micronutrients": {
+      "iron_mg": 3.1,
+      "vitamin_d_iu": 120,
+      "selenium_mcg": 31
+    },
+    "vitamins": [
+      "vitamin_d",
+      "vitamin_a",
+      "folate"
+    ],
+    "minerals": [
+      "iron",
+      "selenium"
+    ],
+    "cuisine": "Western",
+    "region": "European",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a21",
+    "name": "Chickpea quinoa power bowl",
+    "meal_type": "lunch",
+    "calories": 540,
+    "protein_g": 22,
+    "carbs_g": 72,
+    "fat_g": 16,
+    "fibre_g": 14,
+    "sodium_mg": 300,
+    "tags": [
+      "vegetarian",
+      "high_fibre",
+      "low_salt",
+      "low_gi",
+      "plant_based",
+      "cost_medium"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "grain_bowl",
+      "legume",
+      "plant_based"
+    ],
+    "micronutrients": {
+      "iron_mg": 6.2,
+      "magnesium_mg": 172,
+      "potassium_mg": 910
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium",
+      "potassium"
+    ],
+    "cuisine": "Mediterranean",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a22",
+    "name": "Turkey and hummus wrap",
+    "meal_type": "lunch",
+    "calories": 470,
+    "protein_g": 32,
+    "carbs_g": 44,
+    "fat_g": 18,
+    "fibre_g": 8,
+    "sodium_mg": 520,
+    "tags": [
+      "high_protein",
+      "contains_gluten",
+      "contains_wheat",
+      "contains_sesame",
+      "cost_medium"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat",
+      "sesame"
+    ],
+    "food_categories": [
+      "wrap",
+      "lean_protein",
+      "mediterranean"
+    ],
+    "micronutrients": {
+      "iron_mg": 2.6,
+      "calcium_mg": 140,
+      "potassium_mg": 610
+    },
+    "vitamins": [
+      "niacin",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "iron",
+      "potassium"
+    ],
+    "cuisine": "Turkish",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a23",
+    "name": "Mediterranean tuna salad",
+    "meal_type": "lunch",
+    "calories": 430,
+    "protein_g": 36,
+    "carbs_g": 16,
+    "fat_g": 22,
+    "fibre_g": 7,
+    "sodium_mg": 360,
+    "tags": [
+      "high_protein",
+      "contains_fish",
+      "low_salt",
+      "heart_healthy",
+      "cost_medium"
+    ],
+    "allergens": [
+      "fish"
+    ],
+    "food_categories": [
+      "salad",
+      "seafood",
+      "mediterranean"
+    ],
+    "micronutrients": {
+      "omega3_g": 1.4,
+      "vitamin_e_mg": 3.4,
+      "potassium_mg": 680
+    },
+    "vitamins": [
+      "vitamin_e",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "potassium",
+      "selenium"
+    ],
+    "cuisine": "Greek",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "summer",
+      "spring"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a24",
+    "name": "Tofu soba noodle bowl",
+    "meal_type": "dinner",
+    "calories": 560,
+    "protein_g": 24,
+    "carbs_g": 64,
+    "fat_g": 20,
+    "fibre_g": 9,
+    "sodium_mg": 450,
+    "tags": [
+      "contains_soy",
+      "vegetarian",
+      "high_fibre",
+      "cost_medium",
+      "asian",
+      "low_gi"
+    ],
+    "allergens": [
+      "soy",
+      "gluten"
+    ],
+    "food_categories": [
+      "noodle_bowl",
+      "plant_protein",
+      "asian"
+    ],
+    "micronutrients": {
+      "calcium_mg": 260,
+      "iron_mg": 4.5,
+      "manganese_mg": 1.8
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_k"
+    ],
+    "minerals": [
+      "calcium",
+      "iron",
+      "manganese"
+    ],
+    "cuisine": "Japanese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a25",
+    "name": "Grilled barramundi with quinoa",
+    "meal_type": "dinner",
+    "calories": 530,
+    "protein_g": 41,
+    "carbs_g": 40,
+    "fat_g": 19,
+    "fibre_g": 7,
+    "sodium_mg": 290,
+    "tags": [
+      "high_protein",
+      "contains_fish",
+      "low_salt",
+      "heart_healthy",
+      "cost_high",
+      "omega3_rich"
+    ],
+    "allergens": [
+      "fish"
+    ],
+    "food_categories": [
+      "seafood",
+      "grain_plate",
+      "australian"
+    ],
+    "micronutrients": {
+      "selenium_mcg": 47,
+      "magnesium_mg": 102,
+      "potassium_mg": 840
+    },
+    "vitamins": [
+      "vitamin_d",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "selenium",
+      "magnesium",
+      "potassium"
+    ],
+    "cuisine": "Australian",
+    "region": "Oceania",
+    "seasonal_tags": [
+      "summer",
+      "spring"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a26",
+    "name": "Bean chili with brown rice",
+    "meal_type": "dinner",
+    "calories": 590,
+    "protein_g": 24,
+    "carbs_g": 84,
+    "fat_g": 16,
+    "fibre_g": 15,
+    "sodium_mg": 420,
+    "tags": [
+      "vegetarian",
+      "high_fibre",
+      "low_fat",
+      "low_gi",
+      "cost_low",
+      "soft_food"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "legume",
+      "stew",
+      "plant_based"
+    ],
+    "micronutrients": {
+      "iron_mg": 6.9,
+      "potassium_mg": 980,
+      "magnesium_mg": 146
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Mexican",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a27",
+    "name": "Cottage cheese with cucumber sticks",
+    "meal_type": "snack",
+    "calories": 170,
+    "protein_g": 16,
+    "carbs_g": 8,
+    "fat_g": 7,
+    "fibre_g": 1,
+    "sodium_mg": 280,
+    "tags": [
+      "high_protein",
+      "contains_dairy",
+      "contains_milk",
+      "low_carb",
+      "cost_low"
+    ],
+    "allergens": [
+      "dairy",
+      "milk"
+    ],
+    "food_categories": [
+      "snack",
+      "dairy",
+      "high_protein"
+    ],
+    "micronutrients": {
+      "calcium_mg": 190,
+      "phosphorus_mg": 220
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "vitamin_a"
+    ],
+    "minerals": [
+      "calcium",
+      "phosphorus"
+    ],
+    "cuisine": "Western",
+    "region": "Global",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a28",
+    "name": "Edamame and carrot sticks",
+    "meal_type": "snack",
+    "calories": 160,
+    "protein_g": 12,
+    "carbs_g": 14,
+    "fat_g": 6,
+    "fibre_g": 7,
+    "sodium_mg": 35,
+    "tags": [
+      "contains_soy",
+      "high_protein",
+      "high_fibre",
+      "low_salt",
+      "vegetarian",
+      "cost_low"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "snack",
+      "plant_protein",
+      "vegetable"
+    ],
+    "micronutrients": {
+      "folate_mcg": 160,
+      "vitamin_k_mcg": 32,
+      "iron_mg": 2.1
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_k",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium"
+    ],
+    "cuisine": "Japanese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a29",
+    "name": "Banana peanut smoothie",
+    "meal_type": "snack",
+    "calories": 290,
+    "protein_g": 12,
+    "carbs_g": 34,
+    "fat_g": 12,
+    "fibre_g": 5,
+    "sodium_mg": 140,
+    "tags": [
+      "contains_peanut",
+      "contains_banana",
+      "contains_dairy",
+      "contains_milk",
+      "soft_food",
+      "cost_low"
+    ],
+    "allergens": [
+      "peanut",
+      "banana",
+      "dairy",
+      "milk"
+    ],
+    "food_categories": [
+      "smoothie",
+      "snack",
+      "energy_boost"
+    ],
+    "micronutrients": {
+      "potassium_mg": 620,
+      "calcium_mg": 240,
+      "vitamin_e_mg": 2.8
+    },
+    "vitamins": [
+      "vitamin_b6",
+      "vitamin_e"
+    ],
+    "minerals": [
+      "potassium",
+      "calcium"
+    ],
+    "cuisine": "Global Healthy",
+    "region": "Global",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a30",
+    "name": "Baked sweet potato wedges",
+    "meal_type": "snack",
+    "calories": 190,
+    "protein_g": 3,
+    "carbs_g": 37,
+    "fat_g": 4,
+    "fibre_g": 6,
+    "sodium_mg": 85,
+    "tags": [
+      "low_fat",
+      "high_fibre",
+      "vegetarian",
+      "cost_low",
+      "low_salt"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "snack",
+      "vegetable",
+      "baked"
+    ],
+    "micronutrients": {
+      "vitamin_a_rae": 980,
+      "potassium_mg": 430,
+      "manganese_mg": 0.5
+    },
+    "vitamins": [
+      "vitamin_a",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "potassium",
+      "manganese"
+    ],
+    "cuisine": "Western",
+    "region": "Global",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a31",
+    "name": "Vegetable congee with tofu",
+    "meal_type": "breakfast",
+    "calories": 320,
+    "protein_g": 14,
+    "carbs_g": 48,
+    "fat_g": 8,
+    "fibre_g": 5,
+    "sodium_mg": 280,
+    "tags": [
+      "soft_food",
+      "low_fat",
+      "asian",
+      "contains_soy",
+      "vegetarian",
+      "cost_low",
+      "low_salt"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "congee",
+      "plant_protein",
+      "breakfast_bowl"
+    ],
+    "micronutrients": {
+      "iron_mg": 2.7,
+      "potassium_mg": 410,
+      "folate_mcg": 88
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_b1"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Chinese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 30,
+    "total_time_minutes": 40,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a32",
+    "name": "Miso salmon rice bowl",
+    "meal_type": "lunch",
+    "calories": 560,
+    "protein_g": 38,
+    "carbs_g": 54,
+    "fat_g": 20,
+    "fibre_g": 6,
+    "sodium_mg": 520,
+    "tags": [
+      "high_protein",
+      "contains_fish",
+      "contains_soy",
+      "asian",
+      "omega3_rich",
+      "cost_high"
+    ],
+    "allergens": [
+      "fish",
+      "soy"
+    ],
+    "food_categories": [
+      "rice_bowl",
+      "seafood",
+      "japanese"
+    ],
+    "micronutrients": {
+      "selenium_mcg": 40,
+      "vitamin_d_iu": 430,
+      "potassium_mg": 760
+    },
+    "vitamins": [
+      "vitamin_d",
+      "vitamin_b12",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "selenium",
+      "potassium",
+      "phosphorus"
+    ],
+    "cuisine": "Japanese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 20,
+    "total_time_minutes": 35,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a33",
+    "name": "Kimchi tofu bibimbap",
+    "meal_type": "dinner",
+    "calories": 610,
+    "protein_g": 24,
+    "carbs_g": 76,
+    "fat_g": 20,
+    "fibre_g": 10,
+    "sodium_mg": 690,
+    "tags": [
+      "asian",
+      "contains_soy",
+      "vegetarian",
+      "high_fibre",
+      "cost_medium"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "rice_bowl",
+      "korean",
+      "fermented_food"
+    ],
+    "micronutrients": {
+      "iron_mg": 4.1,
+      "vitamin_c_mg": 26,
+      "calcium_mg": 230
+    },
+    "vitamins": [
+      "vitamin_c",
+      "folate",
+      "vitamin_k"
+    ],
+    "minerals": [
+      "iron",
+      "calcium",
+      "magnesium"
+    ],
+    "cuisine": "Korean",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 20,
+    "cook_time_minutes": 25,
+    "total_time_minutes": 45,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a34",
+    "name": "Thai basil chicken with jasmine rice",
+    "meal_type": "dinner",
+    "calories": 590,
+    "protein_g": 36,
+    "carbs_g": 58,
+    "fat_g": 22,
+    "fibre_g": 5,
+    "sodium_mg": 640,
+    "tags": [
+      "high_protein",
+      "asian",
+      "cost_medium"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "stir_fry",
+      "thai",
+      "rice_plate"
+    ],
+    "micronutrients": {
+      "iron_mg": 2.8,
+      "potassium_mg": 680,
+      "vitamin_b6_mg": 0.8
+    },
+    "vitamins": [
+      "vitamin_b6",
+      "niacin"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "phosphorus"
+    ],
+    "cuisine": "Thai",
+    "region": "Asian",
+    "seasonal_tags": [
+      "summer",
+      "spring"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 18,
+    "total_time_minutes": 33,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a35",
+    "name": "Chana masala with brown rice",
+    "meal_type": "lunch",
+    "calories": 570,
+    "protein_g": 21,
+    "carbs_g": 82,
+    "fat_g": 16,
+    "fibre_g": 14,
+    "sodium_mg": 430,
+    "tags": [
+      "indian",
+      "vegetarian",
+      "high_fibre",
+      "low_gi",
+      "cost_low"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "curry",
+      "legume",
+      "grain_plate"
+    ],
+    "micronutrients": {
+      "iron_mg": 6.3,
+      "folate_mcg": 210,
+      "potassium_mg": 920
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Indian",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 30,
+    "total_time_minutes": 45,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a36",
+    "name": "Greek shakshuka with feta",
+    "meal_type": "breakfast",
+    "calories": 390,
+    "protein_g": 22,
+    "carbs_g": 20,
+    "fat_g": 24,
+    "fibre_g": 6,
+    "sodium_mg": 470,
+    "tags": [
+      "high_protein",
+      "contains_egg",
+      "contains_dairy",
+      "mediterranean",
+      "cost_medium"
+    ],
+    "allergens": [
+      "egg",
+      "dairy"
+    ],
+    "food_categories": [
+      "egg_based",
+      "stewed_vegetables",
+      "mediterranean"
+    ],
+    "micronutrients": {
+      "lycopene_mg": 12,
+      "calcium_mg": 210,
+      "iron_mg": 3.2
+    },
+    "vitamins": [
+      "vitamin_a",
+      "vitamin_c",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "calcium",
+      "iron",
+      "potassium"
+    ],
+    "cuisine": "Greek",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "spring",
+      "summer"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 18,
+    "total_time_minutes": 30,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a37",
+    "name": "Italian minestrone with cannellini beans",
+    "meal_type": "dinner",
+    "calories": 460,
+    "protein_g": 18,
+    "carbs_g": 66,
+    "fat_g": 12,
+    "fibre_g": 13,
+    "sodium_mg": 390,
+    "tags": [
+      "vegetarian",
+      "high_fibre",
+      "mediterranean",
+      "soft_food",
+      "cost_low",
+      "low_fat"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "soup",
+      "italian",
+      "legume"
+    ],
+    "micronutrients": {
+      "iron_mg": 4.4,
+      "potassium_mg": 860,
+      "vitamin_c_mg": 30
+    },
+    "vitamins": [
+      "vitamin_c",
+      "folate",
+      "vitamin_a"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Italian",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 35,
+    "total_time_minutes": 50,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a38",
+    "name": "Turkish lentil kofte lettuce wraps",
+    "meal_type": "lunch",
+    "calories": 440,
+    "protein_g": 17,
+    "carbs_g": 58,
+    "fat_g": 14,
+    "fibre_g": 12,
+    "sodium_mg": 300,
+    "tags": [
+      "vegetarian",
+      "high_fibre",
+      "low_salt",
+      "mediterranean",
+      "cost_low"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "wrap",
+      "legume",
+      "turkish"
+    ],
+    "micronutrients": {
+      "iron_mg": 5.1,
+      "folate_mcg": 170,
+      "magnesium_mg": 96
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium",
+      "potassium"
+    ],
+    "cuisine": "Turkish",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 20,
+    "cook_time_minutes": 20,
+    "total_time_minutes": 40,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a39",
+    "name": "Mexican chicken fajita bowl",
+    "meal_type": "lunch",
+    "calories": 550,
+    "protein_g": 35,
+    "carbs_g": 56,
+    "fat_g": 20,
+    "fibre_g": 9,
+    "sodium_mg": 510,
+    "tags": [
+      "high_protein",
+      "latin_american",
+      "cost_medium",
+      "high_fibre"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "rice_bowl",
+      "mexican",
+      "lean_protein"
+    ],
+    "micronutrients": {
+      "vitamin_c_mg": 45,
+      "iron_mg": 2.9,
+      "potassium_mg": 760
+    },
+    "vitamins": [
+      "vitamin_c",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Mexican",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "summer",
+      "spring"
+    ],
+    "prep_time_minutes": 18,
+    "cook_time_minutes": 18,
+    "total_time_minutes": 36,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a40",
+    "name": "Brazilian black bean stew with farofa",
+    "meal_type": "dinner",
+    "calories": 620,
+    "protein_g": 27,
+    "carbs_g": 78,
+    "fat_g": 22,
+    "fibre_g": 14,
+    "sodium_mg": 540,
+    "tags": [
+      "latin_american",
+      "high_fibre",
+      "cost_medium"
+    ],
+    "allergens": [
+      "gluten"
+    ],
+    "food_categories": [
+      "stew",
+      "brazilian",
+      "legume"
+    ],
+    "micronutrients": {
+      "iron_mg": 6.7,
+      "potassium_mg": 980,
+      "magnesium_mg": 140
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Brazilian",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 20,
+    "cook_time_minutes": 45,
+    "total_time_minutes": 65,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a41",
+    "name": "Cuban mojo fish with sweet plantain",
+    "meal_type": "dinner",
+    "calories": 540,
+    "protein_g": 34,
+    "carbs_g": 48,
+    "fat_g": 22,
+    "fibre_g": 6,
+    "sodium_mg": 360,
+    "tags": [
+      "contains_fish",
+      "latin_american",
+      "heart_healthy",
+      "cost_medium"
+    ],
+    "allergens": [
+      "fish"
+    ],
+    "food_categories": [
+      "seafood",
+      "cuban",
+      "dinner_plate"
+    ],
+    "micronutrients": {
+      "potassium_mg": 820,
+      "vitamin_c_mg": 34,
+      "selenium_mcg": 32
+    },
+    "vitamins": [
+      "vitamin_c",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "potassium",
+      "selenium"
+    ],
+    "cuisine": "Cuban",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "summer",
+      "spring"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 22,
+    "total_time_minutes": 37,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a42",
+    "name": "Chicken shawarma quinoa tabbouleh",
+    "meal_type": "lunch",
+    "calories": 530,
+    "protein_g": 36,
+    "carbs_g": 50,
+    "fat_g": 18,
+    "fibre_g": 8,
+    "sodium_mg": 480,
+    "tags": [
+      "high_protein",
+      "middle_eastern",
+      "cost_medium"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "salad_bowl",
+      "middle_eastern",
+      "lean_protein"
+    ],
+    "micronutrients": {
+      "iron_mg": 3.1,
+      "vitamin_c_mg": 28,
+      "potassium_mg": 700
+    },
+    "vitamins": [
+      "vitamin_c",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Levantine",
+    "region": "Middle Eastern",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 20,
+    "cook_time_minutes": 18,
+    "total_time_minutes": 38,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a43",
+    "name": "Persian herb frittata with yoghurt",
+    "meal_type": "breakfast",
+    "calories": 370,
+    "protein_g": 23,
+    "carbs_g": 12,
+    "fat_g": 24,
+    "fibre_g": 4,
+    "sodium_mg": 340,
+    "tags": [
+      "contains_egg",
+      "contains_dairy",
+      "middle_eastern",
+      "high_protein",
+      "cost_medium"
+    ],
+    "allergens": [
+      "egg",
+      "dairy"
+    ],
+    "food_categories": [
+      "egg_based",
+      "persian",
+      "breakfast"
+    ],
+    "micronutrients": {
+      "vitamin_k_mcg": 140,
+      "calcium_mg": 180,
+      "iron_mg": 3.0
+    },
+    "vitamins": [
+      "vitamin_k",
+      "vitamin_b12",
+      "vitamin_d"
+    ],
+    "minerals": [
+      "calcium",
+      "iron",
+      "phosphorus"
+    ],
+    "cuisine": "Persian",
+    "region": "Middle Eastern",
+    "seasonal_tags": [
+      "spring"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 18,
+    "total_time_minutes": 33,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a44",
+    "name": "Baked falafel pita pocket",
+    "meal_type": "lunch",
+    "calories": 500,
+    "protein_g": 19,
+    "carbs_g": 62,
+    "fat_g": 18,
+    "fibre_g": 11,
+    "sodium_mg": 520,
+    "tags": [
+      "middle_eastern",
+      "vegetarian",
+      "high_fibre",
+      "contains_gluten",
+      "contains_wheat",
+      "contains_sesame",
+      "cost_low"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat",
+      "sesame"
+    ],
+    "food_categories": [
+      "pita",
+      "legume",
+      "middle_eastern"
+    ],
+    "micronutrients": {
+      "iron_mg": 4.2,
+      "folate_mcg": 150,
+      "magnesium_mg": 92
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium",
+      "zinc"
+    ],
+    "cuisine": "Middle Eastern",
+    "region": "Middle Eastern",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 20,
+    "cook_time_minutes": 25,
+    "total_time_minutes": 45,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a45",
+    "name": "Japanese overnight matcha oats",
+    "meal_type": "breakfast",
+    "calories": 330,
+    "protein_g": 13,
+    "carbs_g": 45,
+    "fat_g": 10,
+    "fibre_g": 7,
+    "sodium_mg": 120,
+    "tags": [
+      "vegetarian",
+      "high_fibre",
+      "asian",
+      "contains_dairy",
+      "cost_low"
+    ],
+    "allergens": [
+      "dairy"
+    ],
+    "food_categories": [
+      "overnight_oats",
+      "breakfast_bowl",
+      "japanese"
+    ],
+    "micronutrients": {
+      "calcium_mg": 230,
+      "iron_mg": 2.8,
+      "potassium_mg": 360
+    },
+    "vitamins": [
+      "vitamin_b1",
+      "vitamin_e"
+    ],
+    "minerals": [
+      "calcium",
+      "iron",
+      "magnesium"
+    ],
+    "cuisine": "Japanese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "summer"
+    ],
+    "prep_time_minutes": 8,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 8,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a46",
+    "name": "Thai green papaya salad with tofu",
+    "meal_type": "lunch",
+    "calories": 420,
+    "protein_g": 20,
+    "carbs_g": 38,
+    "fat_g": 18,
+    "fibre_g": 8,
+    "sodium_mg": 410,
+    "tags": [
+      "asian",
+      "contains_soy",
+      "high_fibre",
+      "low_gi",
+      "cost_medium"
+    ],
+    "allergens": [
+      "soy",
+      "peanut"
+    ],
+    "food_categories": [
+      "salad",
+      "thai",
+      "plant_protein"
+    ],
+    "micronutrients": {
+      "vitamin_c_mg": 52,
+      "iron_mg": 3.0,
+      "potassium_mg": 610
+    },
+    "vitamins": [
+      "vitamin_c",
+      "folate"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Thai",
+    "region": "Asian",
+    "seasonal_tags": [
+      "summer"
+    ],
+    "prep_time_minutes": 18,
+    "cook_time_minutes": 5,
+    "total_time_minutes": 23,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a47",
+    "name": "Indian dal khichdi",
+    "meal_type": "dinner",
+    "calories": 510,
+    "protein_g": 20,
+    "carbs_g": 74,
+    "fat_g": 14,
+    "fibre_g": 11,
+    "sodium_mg": 350,
+    "tags": [
+      "indian",
+      "vegetarian",
+      "soft_food",
+      "high_fibre",
+      "low_fat",
+      "cost_low"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "one_pot",
+      "legume",
+      "comfort_food"
+    ],
+    "micronutrients": {
+      "iron_mg": 4.9,
+      "magnesium_mg": 118,
+      "potassium_mg": 760
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_b1"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium",
+      "potassium"
+    ],
+    "cuisine": "Indian",
+    "region": "Asian",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 30,
+    "total_time_minutes": 42,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a48",
+    "name": "Italian caprese quinoa salad",
+    "meal_type": "dinner",
+    "calories": 470,
+    "protein_g": 18,
+    "carbs_g": 42,
+    "fat_g": 24,
+    "fibre_g": 7,
+    "sodium_mg": 390,
+    "tags": [
+      "mediterranean",
+      "vegetarian",
+      "contains_dairy",
+      "cost_medium"
+    ],
+    "allergens": [
+      "dairy"
+    ],
+    "food_categories": [
+      "salad",
+      "italian",
+      "grain_plate"
+    ],
+    "micronutrients": {
+      "calcium_mg": 240,
+      "vitamin_c_mg": 22,
+      "potassium_mg": 580
+    },
+    "vitamins": [
+      "vitamin_c",
+      "vitamin_k"
+    ],
+    "minerals": [
+      "calcium",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Italian",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "summer"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 30,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a49",
+    "name": "Greek lemon chicken soup",
+    "meal_type": "dinner",
+    "calories": 430,
+    "protein_g": 32,
+    "carbs_g": 30,
+    "fat_g": 18,
+    "fibre_g": 4,
+    "sodium_mg": 460,
+    "tags": [
+      "mediterranean",
+      "high_protein",
+      "soft_food",
+      "cost_medium"
+    ],
+    "allergens": [
+      "egg"
+    ],
+    "food_categories": [
+      "soup",
+      "greek",
+      "lean_protein"
+    ],
+    "micronutrients": {
+      "selenium_mcg": 30,
+      "vitamin_c_mg": 18,
+      "potassium_mg": 620
+    },
+    "vitamins": [
+      "vitamin_c",
+      "vitamin_b6"
+    ],
+    "minerals": [
+      "selenium",
+      "potassium"
+    ],
+    "cuisine": "Greek",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "fall",
+      "winter"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 30,
+    "total_time_minutes": 45,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a50",
+    "name": "Mexican huevos rancheros",
+    "meal_type": "breakfast",
+    "calories": 410,
+    "protein_g": 22,
+    "carbs_g": 36,
+    "fat_g": 20,
+    "fibre_g": 9,
+    "sodium_mg": 470,
+    "tags": [
+      "latin_american",
+      "contains_egg",
+      "high_protein",
+      "high_fibre",
+      "cost_low"
+    ],
+    "allergens": [
+      "egg"
+    ],
+    "food_categories": [
+      "egg_based",
+      "mexican",
+      "breakfast_plate"
+    ],
+    "micronutrients": {
+      "iron_mg": 3.5,
+      "potassium_mg": 700,
+      "folate_mcg": 120
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_c",
+      "vitamin_a"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Mexican",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 27,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a51",
+    "name": "Brazilian acai yoghurt bowl",
+    "meal_type": "breakfast",
+    "calories": 360,
+    "protein_g": 15,
+    "carbs_g": 44,
+    "fat_g": 14,
+    "fibre_g": 8,
+    "sodium_mg": 95,
+    "tags": [
+      "latin_american",
+      "contains_dairy",
+      "high_fibre",
+      "cost_medium",
+      "probiotic"
+    ],
+    "allergens": [
+      "dairy",
+      "tree_nut"
+    ],
+    "food_categories": [
+      "breakfast_bowl",
+      "brazilian",
+      "fruit"
+    ],
+    "micronutrients": {
+      "calcium_mg": 250,
+      "vitamin_c_mg": 35,
+      "manganese_mg": 1.6
+    },
+    "vitamins": [
+      "vitamin_c",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "calcium",
+      "manganese",
+      "potassium"
+    ],
+    "cuisine": "Brazilian",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "summer"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 10,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a52",
+    "name": "Cuban black bean rice bowl",
+    "meal_type": "lunch",
+    "calories": 540,
+    "protein_g": 20,
+    "carbs_g": 84,
+    "fat_g": 12,
+    "fibre_g": 14,
+    "sodium_mg": 420,
+    "tags": [
+      "latin_american",
+      "vegetarian",
+      "high_fibre",
+      "low_fat",
+      "cost_low"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "rice_bowl",
+      "cuban",
+      "legume"
+    ],
+    "micronutrients": {
+      "iron_mg": 5.9,
+      "potassium_mg": 940,
+      "folate_mcg": 210
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Cuban",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 30,
+    "total_time_minutes": 45,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a53",
+    "name": "Middle Eastern zaatar baked eggs",
+    "meal_type": "breakfast",
+    "calories": 340,
+    "protein_g": 21,
+    "carbs_g": 14,
+    "fat_g": 22,
+    "fibre_g": 4,
+    "sodium_mg": 330,
+    "tags": [
+      "middle_eastern",
+      "contains_egg",
+      "high_protein",
+      "cost_low"
+    ],
+    "allergens": [
+      "egg"
+    ],
+    "food_categories": [
+      "egg_based",
+      "middle_eastern",
+      "baked"
+    ],
+    "micronutrients": {
+      "iron_mg": 2.9,
+      "vitamin_a_rae": 260,
+      "selenium_mcg": 28
+    },
+    "vitamins": [
+      "vitamin_a",
+      "vitamin_d",
+      "vitamin_b12"
+    ],
+    "minerals": [
+      "iron",
+      "selenium"
+    ],
+    "cuisine": "Middle Eastern",
+    "region": "Middle Eastern",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 8,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 23,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a54",
+    "name": "Lamb kofta with bulgur and salad",
+    "meal_type": "dinner",
+    "calories": 650,
+    "protein_g": 34,
+    "carbs_g": 48,
+    "fat_g": 34,
+    "fibre_g": 7,
+    "sodium_mg": 560,
+    "tags": [
+      "middle_eastern",
+      "high_protein",
+      "cost_high"
+    ],
+    "allergens": [
+      "gluten",
+      "wheat"
+    ],
+    "food_categories": [
+      "grill",
+      "red_meat",
+      "middle_eastern"
+    ],
+    "micronutrients": {
+      "iron_mg": 5.6,
+      "zinc_mg": 6.0,
+      "vitamin_b12_mcg": 2.4
+    },
+    "vitamins": [
+      "vitamin_b12",
+      "niacin"
+    ],
+    "minerals": [
+      "iron",
+      "zinc",
+      "phosphorus"
+    ],
+    "cuisine": "Middle Eastern",
+    "region": "Middle Eastern",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 22,
+    "cook_time_minutes": 20,
+    "total_time_minutes": 42,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a55",
+    "name": "Japanese onigiri with edamame",
+    "meal_type": "snack",
+    "calories": 240,
+    "protein_g": 10,
+    "carbs_g": 34,
+    "fat_g": 6,
+    "fibre_g": 5,
+    "sodium_mg": 210,
+    "tags": [
+      "asian",
+      "contains_soy",
+      "cost_low",
+      "low_fat"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "snack",
+      "japanese",
+      "rice_based"
+    ],
+    "micronutrients": {
+      "folate_mcg": 100,
+      "iron_mg": 1.9,
+      "potassium_mg": 360
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_b1"
+    ],
+    "minerals": [
+      "iron",
+      "potassium"
+    ],
+    "cuisine": "Japanese",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 12,
+    "cook_time_minutes": 10,
+    "total_time_minutes": 22,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a56",
+    "name": "Korean roasted seaweed tofu rolls",
+    "meal_type": "snack",
+    "calories": 210,
+    "protein_g": 12,
+    "carbs_g": 20,
+    "fat_g": 9,
+    "fibre_g": 4,
+    "sodium_mg": 260,
+    "tags": [
+      "asian",
+      "contains_soy",
+      "high_protein",
+      "cost_low"
+    ],
+    "allergens": [
+      "soy"
+    ],
+    "food_categories": [
+      "snack",
+      "korean",
+      "seaweed"
+    ],
+    "micronutrients": {
+      "iodine_mcg": 65,
+      "calcium_mg": 180,
+      "iron_mg": 2.4
+    },
+    "vitamins": [
+      "vitamin_k",
+      "folate"
+    ],
+    "minerals": [
+      "iodine",
+      "calcium",
+      "iron"
+    ],
+    "cuisine": "Korean",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 5,
+    "total_time_minutes": 20,
+    "difficulty": "medium"
+  },
+  {
+    "id": "a57",
+    "name": "Thai mango sticky rice cup",
+    "meal_type": "snack",
+    "calories": 260,
+    "protein_g": 4,
+    "carbs_g": 48,
+    "fat_g": 7,
+    "fibre_g": 3,
+    "sodium_mg": 40,
+    "tags": [
+      "asian",
+      "dessert",
+      "contains_mango",
+      "vegetarian",
+      "cost_low"
+    ],
+    "allergens": [
+      "mango"
+    ],
+    "food_categories": [
+      "snack",
+      "thai",
+      "dessert"
+    ],
+    "micronutrients": {
+      "vitamin_c_mg": 24,
+      "potassium_mg": 280,
+      "manganese_mg": 0.9
+    },
+    "vitamins": [
+      "vitamin_c"
+    ],
+    "minerals": [
+      "potassium",
+      "manganese"
+    ],
+    "cuisine": "Thai",
+    "region": "Asian",
+    "seasonal_tags": [
+      "summer"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 15,
+    "total_time_minutes": 25,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a58",
+    "name": "Indian roasted chickpea chaat",
+    "meal_type": "snack",
+    "calories": 220,
+    "protein_g": 9,
+    "carbs_g": 30,
+    "fat_g": 8,
+    "fibre_g": 8,
+    "sodium_mg": 180,
+    "tags": [
+      "indian",
+      "vegetarian",
+      "high_fibre",
+      "cost_low",
+      "low_fat"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "snack",
+      "legume",
+      "indian"
+    ],
+    "micronutrients": {
+      "iron_mg": 2.8,
+      "folate_mcg": 90,
+      "potassium_mg": 420
+    },
+    "vitamins": [
+      "folate",
+      "vitamin_c"
+    ],
+    "minerals": [
+      "iron",
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Indian",
+    "region": "Asian",
+    "seasonal_tags": [
+      "all-season"
+    ],
+    "prep_time_minutes": 15,
+    "cook_time_minutes": 10,
+    "total_time_minutes": 25,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a59",
+    "name": "Mediterranean hummus veggie cup",
+    "meal_type": "snack",
+    "calories": 190,
+    "protein_g": 7,
+    "carbs_g": 18,
+    "fat_g": 10,
+    "fibre_g": 6,
+    "sodium_mg": 170,
+    "tags": [
+      "mediterranean",
+      "vegetarian",
+      "high_fibre",
+      "contains_sesame",
+      "cost_low"
+    ],
+    "allergens": [
+      "sesame"
+    ],
+    "food_categories": [
+      "snack",
+      "dip",
+      "vegetable"
+    ],
+    "micronutrients": {
+      "iron_mg": 2.2,
+      "vitamin_c_mg": 18,
+      "magnesium_mg": 42
+    },
+    "vitamins": [
+      "vitamin_c",
+      "folate"
+    ],
+    "minerals": [
+      "iron",
+      "magnesium"
+    ],
+    "cuisine": "Mediterranean",
+    "region": "Mediterranean",
+    "seasonal_tags": [
+      "spring",
+      "summer"
+    ],
+    "prep_time_minutes": 8,
+    "cook_time_minutes": 0,
+    "total_time_minutes": 8,
+    "difficulty": "easy"
+  },
+  {
+    "id": "a60",
+    "name": "Mexican corn and avocado salsa cup",
+    "meal_type": "snack",
+    "calories": 200,
+    "protein_g": 5,
+    "carbs_g": 24,
+    "fat_g": 10,
+    "fibre_g": 6,
+    "sodium_mg": 140,
+    "tags": [
+      "latin_american",
+      "vegetarian",
+      "high_fibre",
+      "low_salt",
+      "cost_low"
+    ],
+    "allergens": [],
+    "food_categories": [
+      "snack",
+      "mexican",
+      "vegetable"
+    ],
+    "micronutrients": {
+      "vitamin_c_mg": 26,
+      "potassium_mg": 410,
+      "folate_mcg": 70
+    },
+    "vitamins": [
+      "vitamin_c",
+      "folate"
+    ],
+    "minerals": [
+      "potassium",
+      "magnesium"
+    ],
+    "cuisine": "Mexican",
+    "region": "Latin American",
+    "seasonal_tags": [
+      "summer"
+    ],
+    "prep_time_minutes": 10,
+    "cook_time_minutes": 8,
+    "total_time_minutes": 18,
+    "difficulty": "easy"
+  }
+]

--- a/routes/ai/finetuneChat.js
+++ b/routes/ai/finetuneChat.js
@@ -1,0 +1,84 @@
+const express = require('express');
+const router = express.Router();
+
+const HF_SPACE_URL = (process.env.HF_SPACE_URL || 'https://ngtuanphong-nutribot.hf.space').replace(/\/$/, '');
+const HF_SPACE_KEY = (process.env.HF_SPACE_KEY || '').trim();
+
+function buildHeaders(extra = {}) {
+  const headers = { 'Content-Type': 'application/json', ...extra };
+  if (HF_SPACE_KEY) headers['Authorization'] = `Bearer ${HF_SPACE_KEY}`;
+  return headers;
+}
+
+async function fetchWithTimeout(url, options, timeoutMs = 180000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// GET /ai-model/chatbot-finetune/healthz
+router.get('/healthz', async (_req, res) => {
+  try {
+    const resp = await fetchWithTimeout(`${HF_SPACE_URL}/healthz`, { headers: buildHeaders() }, 30000);
+    let body = {};
+    try { body = await resp.json(); } catch { body = { raw: '' }; }
+    return res.json({ ok: resp.ok, space_status: resp.status, space_health: body, space_url: HF_SPACE_URL });
+  } catch (err) {
+    return res.status(502).json({
+      status: 'error',
+      error: 'Cannot reach Space',
+      detail: `${err.constructor.name}: ${err.message}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+});
+
+// POST /ai-model/chatbot-finetune/chat
+router.post('/chat', async (req, res) => {
+  try {
+    await fetchWithTimeout(`${HF_SPACE_URL}/healthz`, { headers: buildHeaders() }, 30000).catch(() => {});
+  } catch { /* non-fatal preflight */ }
+
+  let lastErr = null;
+  const delays = [0, 1500, 3000];
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (delays[attempt]) await new Promise((r) => setTimeout(r, delays[attempt]));
+    try {
+      const resp = await fetchWithTimeout(
+        `${HF_SPACE_URL}/v1/chat/completions`,
+        { method: 'POST', headers: buildHeaders(), body: JSON.stringify(req.body) },
+        180000
+      );
+      if (!resp.ok) {
+        const text = await resp.text();
+        return res.status(resp.status).json({
+          status: 'error',
+          error: 'Space error',
+          detail: text.slice(0, 500) + (text.length > 500 ? '…' : ''),
+          timestamp: new Date().toISOString(),
+        });
+      }
+      const data = await resp.json();
+      return res.json(data);
+    } catch (err) {
+      lastErr = err;
+      if (err.name !== 'AbortError') continue;
+      break;
+    }
+  }
+
+  const isTimeout = lastErr && (lastErr.name === 'AbortError' || lastErr.code === 'UND_ERR_CONNECT_TIMEOUT');
+  return res.status(isTimeout ? 504 : 502).json({
+    status: 'error',
+    error: isTimeout ? 'Gateway timeout reaching Space' : 'Upstream error reaching Space',
+    detail: lastErr ? `${lastErr.constructor.name}: ${lastErr.message}` : 'Unknown error',
+    timestamp: new Date().toISOString(),
+  });
+});
+
+module.exports = router;

--- a/routes/ai/imageAnalysis.js
+++ b/routes/ai/imageAnalysis.js
@@ -1,0 +1,93 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const multer = require('multer');
+
+const predictionController = require('../../controller/imageClassificationController');
+const gateway = require('../../services/imageClassificationGateway');
+const { validateImageUpload, MAX_SIZE_BYTES, ALLOWED_MIME_TYPES } = require('../../validators/imageValidator');
+const { validationError, fail, ok } = require('../../utils/apiResponse');
+const { msg } = require('../../utils/messages');
+const { buildImageScanPayload, SCAN_CONTRACT_VERSION } = require('../../services/scanContractService');
+const logger = require('../../utils/logger');
+
+const router = express.Router();
+
+const uploadsDir = path.join(__dirname, '..', '..', 'uploads');
+if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
+
+const upload = multer({
+  dest: uploadsDir,
+  limits: { fileSize: MAX_SIZE_BYTES },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) return cb(null, true);
+    const err = new Error('invalid_mime');
+    err.code = 'INVALID_MIME';
+    return cb(err);
+  },
+});
+
+function handleSingleUpload(req, res, next) {
+  upload.single('file')(req, res, (err) => {
+    if (!err) return next();
+    if (err.code === 'LIMIT_FILE_SIZE') return validationError(res, [{ field: 'file', message: msg('image.too_large') }]);
+    if (err.code === 'INVALID_MIME') return validationError(res, [{ field: 'file', message: msg('image.invalid_type') }]);
+    return fail(res, msg('image.no_file'), 400, 'UPLOAD_FAILED');
+  });
+}
+
+// POST /ai-model/image-analysis/image-analysis
+router.post('/image-analysis', handleSingleUpload, validateImageUpload, predictionController.predictImage);
+
+// POST /ai-model/image-analysis/multi-image-analysis
+router.post('/multi-image-analysis', (req, res, next) => {
+  upload.array('files', 10)(req, res, (err) => {
+    if (err && err.code === 'LIMIT_FILE_SIZE') return validationError(res, [{ field: 'files', message: msg('image.too_large') }]);
+    if (err && err.code === 'INVALID_MIME') return validationError(res, [{ field: 'files', message: msg('image.invalid_type') }]);
+    if (err) return fail(res, msg('image.no_file'), 400, 'UPLOAD_FAILED');
+    next();
+  });
+}, async (req, res) => {
+  if (!req.files || req.files.length === 0) {
+    return fail(res, msg('image.no_file'), 400, 'IMAGE_MISSING');
+  }
+
+  const predictions = [];
+
+  for (const file of req.files) {
+    try {
+      const imageData = await fs.promises.readFile(file.path);
+      const result = await gateway.classify(imageData);
+
+      if (result.ok) {
+        predictions.push({
+          ok: true,
+          classification: result.data.classification,
+          explainability: result.data.explainability,
+          imageName: file.originalname || null,
+        });
+      } else {
+        predictions.push({
+          ok: false,
+          error: result.error || 'Classification failed',
+          code: result.code || 'CLASSIFICATION_ERROR',
+          imageName: file.originalname || null,
+        });
+      }
+    } catch (err) {
+      logger.error('Multi-image: failed to process file', { error: err.message, file: file.originalname });
+      predictions.push({
+        ok: false,
+        error: 'Failed to process image',
+        code: 'INTERNAL_ERROR',
+        imageName: file.originalname || null,
+      });
+    } finally {
+      fs.unlink(file.path, () => {});
+    }
+  }
+
+  return res.json({ predictions });
+});
+
+module.exports = router;

--- a/routes/ai/mealLog.js
+++ b/routes/ai/mealLog.js
@@ -1,0 +1,86 @@
+const express = require('express');
+const router = express.Router();
+const mealLogService = require('../../services/mealLogService');
+
+// POST /ai-model/meals/log-scan
+router.post('/log-scan', (req, res) => {
+  try {
+    const entry = mealLogService.createEntry(req.body || {});
+    const daily_summary = mealLogService.getDailySummary({ targetDate: entry.date, userId: entry.user_id });
+    return res.status(201).json({ entry, daily_summary });
+  } catch (err) {
+    if (err.message && err.message.startsWith('Invalid')) return res.status(400).json({ error: err.message });
+    return res.status(500).json({ error: 'Failed to save meal log entry.' });
+  }
+});
+
+// GET /ai-model/meals/nutrition-preview?label=...
+router.get('/nutrition-preview', (req, res) => {
+  const label = String(req.query.label || '').trim();
+  if (!label) return res.status(400).json({ error: 'Label is required.' });
+  const { lookup } = require('../../services/nutritionLookupService');
+  const preview = lookup(label);
+  return res.json({ label, ...preview });
+});
+
+// GET /ai-model/meals/logs?date=YYYY-MM-DD&user_id=...
+router.get('/logs', (req, res) => {
+  try {
+    const entries = mealLogService.listEntries({
+      targetDate: req.query.date || null,
+      userId: req.query.user_id || null,
+    });
+    return res.json(entries);
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /ai-model/meals/logs/:entry_id?user_id=...
+router.delete('/logs/:entry_id', (req, res) => {
+  const deleted = mealLogService.deleteEntry(req.params.entry_id, req.query.user_id || null);
+  if (!deleted) return res.status(404).json({ error: 'Meal log entry not found.' });
+  return res.json({ deleted: true, entry_id: req.params.entry_id });
+});
+
+// GET /ai-model/meals/daily-summary?date=YYYY-MM-DD&user_id=...
+router.get('/daily-summary', (req, res) => {
+  try {
+    const summary = mealLogService.getDailySummary({
+      targetDate: req.query.date || null,
+      userId: req.query.user_id || null,
+    });
+    return res.json(summary);
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /ai-model/meals/chat-context?date=YYYY-MM-DD&user_id=...
+router.get('/chat-context', (req, res) => {
+  try {
+    const context = mealLogService.buildChatContext({
+      targetDate: req.query.date || null,
+      userId: req.query.user_id || null,
+    });
+    return res.json(context);
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /ai-model/meals/plan-context?date_to=YYYY-MM-DD&days=7&user_id=...
+router.get('/plan-context', (req, res) => {
+  try {
+    const context = mealLogService.buildPlanContext({
+      userId: req.query.user_id || null,
+      dateTo: req.query.date_to || null,
+      days: req.query.days ? parseInt(req.query.days) : 7,
+    });
+    return res.json(context);
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/routes/ai/mealPlan.js
+++ b/routes/ai/mealPlan.js
@@ -1,0 +1,386 @@
+const express = require('express');
+const path = require('path');
+const router = express.Router();
+
+const MEAL_LIBRARY_PATH = path.join(__dirname, '..', '..', 'data', 'meal_library.json');
+let MEALS = null;
+function getMeals() {
+  if (!MEALS) MEALS = require(MEAL_LIBRARY_PATH);
+  return MEALS;
+}
+
+// ---- Allergy / Condition maps (ported from meal_generator.py) ----
+const ALLERGY_MAP = {
+  nuts: ['contains_nuts', 'contains_tree_nut', 'contains_peanut'],
+  peanut: ['contains_peanut'],
+  tree_nut: ['contains_tree_nut'],
+  dairy: ['contains_dairy','contains_milk','contains_cheese','contains_yoghurt','contains_butter','contains_cream','contains_whey','contains_casein','contains_lactose'],
+  milk: ['contains_milk','contains_dairy'],
+  egg: ['contains_egg'],
+  soy: ['contains_soy'],
+  gluten: ['contains_gluten','contains_wheat','contains_barley','contains_rye'],
+  wheat: ['contains_wheat','contains_gluten'],
+  shellfish: ['contains_shellfish'],
+  fish: ['contains_fish'],
+  sesame: ['contains_sesame','contains_tahini'],
+};
+
+const CONDITION_MAP = {
+  diabetes: ['high_sugar','high_gi','added_sugar','refined_carb','sugary_drink','dessert','fried','high_saturated_fat','processed_meat','high_salt'],
+  cholesterol: ['high_fat','fried','high_saturated_fat'],
+  high_cholesterol: ['high_fat','fried','high_saturated_fat'],
+  hypertension: ['high_salt','very_high_salt','processed_meat','pickled','soy_sauce_heavy'],
+  high_blood_pressure: ['high_salt','very_high_salt','processed_meat','pickled','soy_sauce_heavy'],
+  kidney_disease: ['high_potassium','high_phosphorus','high_protein'],
+  ckd: ['high_potassium','high_phosphorus','high_protein'],
+  elderly: ['hard_food','crunchy','tough_meat','very_high_salt','fried','very_spicy'],
+};
+
+const CONDITION_PREFERENCE_MAP = {
+  diabetes: ['low_sugar','low_gi','high_fibre','high_protein'],
+  cholesterol: ['heart_healthy','low_fat','high_fibre','omega3_rich'],
+  high_cholesterol: ['heart_healthy','low_fat','high_fibre','omega3_rich'],
+  hypertension: ['low_salt','high_fibre','heart_healthy'],
+  high_blood_pressure: ['low_salt','high_fibre','heart_healthy'],
+  kidney_disease: ['low_salt','low_fat','soft_food'],
+  ckd: ['low_salt','low_fat','soft_food'],
+  elderly: ['soft_food','high_protein','high_fibre'],
+};
+
+const MEAL_TYPE_CALORIE_DISTRIBUTION = { breakfast: 0.25, lunch: 0.35, dinner: 0.30, snack: 0.10 };
+const SORT_KEYS = new Set(['balanced','prep_time','cook_time','total_time','high_protein','high_fibre','low_calories']);
+const SORT_ALIASES = { high_fiber: 'high_fibre', low_calorie: 'low_calories' };
+
+// ---- Helpers ----
+function normalizeList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') return value.split(',').map((v) => v.trim()).filter(Boolean);
+  return [];
+}
+
+function normalizeStringList(values) {
+  return values.map((v) => String(v).trim().toLowerCase()).filter(Boolean);
+}
+
+function mealTagsLower(meal) { return normalizeStringList(meal.tags || []); }
+function mealAllergensLower(meal) { return normalizeStringList(meal.allergens || []); }
+function mealCategoriesLower(meal) { return normalizeStringList(meal.food_categories || []); }
+function mealCuisinesLower(meal) {
+  const raw = [];
+  if (meal.cuisine) raw.push(meal.cuisine);
+  if (meal.region) raw.push(meal.region);
+  raw.push(...(meal.tags || []), ...(meal.food_categories || []));
+  return normalizeStringList(raw);
+}
+function mealSeasonsLower(meal) {
+  let s = normalizeStringList(meal.seasonal_tags || []);
+  if (!s.length) s = ['all-season'];
+  if (s.includes('all_season') && !s.includes('all-season')) s.push('all-season');
+  return s;
+}
+
+function mealContainsAllergen(meal, allergy) {
+  const tags = new Set(mealTagsLower(meal));
+  const allergens = new Set(mealAllergensLower(meal));
+  const mapped = new Set(ALLERGY_MAP[allergy] || []);
+  return allergens.has(allergy) || [...mapped].some((t) => tags.has(t) || allergens.has(t));
+}
+
+// ---- Filters ----
+function filterAllergy(meals, allergies) {
+  const al = normalizeStringList(allergies);
+  if (!al.length) return meals;
+  return meals.filter((m) => !al.some((a) => mealContainsAllergen(m, a)));
+}
+
+function filterCondition(meals, conditions) {
+  const cl = normalizeStringList(conditions);
+  if (!cl.length) return meals;
+  return meals.filter((meal) => {
+    const tags = new Set(mealTagsLower(meal));
+    for (const condition of cl) {
+      const bad = CONDITION_MAP[condition] || [];
+      if (bad.some((t) => tags.has(t))) return false;
+      const sodium = Number(meal.sodium_mg) || 0;
+      if ((condition === 'hypertension' || condition === 'high_blood_pressure') && sodium > 800) return false;
+    }
+    return true;
+  });
+}
+
+function filterTexture(meals, texture) {
+  if ((texture || 'normal').toLowerCase() !== 'soft') return meals;
+  return meals.filter((m) => mealTagsLower(m).includes('soft_food'));
+}
+
+function filterBudget(meals, budget) {
+  const b = String(budget || 'medium').toLowerCase();
+  if (b === 'low') {
+    for (const allowed of [['cost_low'], ['cost_low','cost_medium'], ['cost_low','cost_medium','cost_high']]) {
+      const f = meals.filter((m) => allowed.some((t) => mealTagsLower(m).includes(t)));
+      if (f.length) return f;
+    }
+  } else if (b === 'medium') {
+    for (const allowed of [['cost_medium'], ['cost_medium','cost_low'], ['cost_medium','cost_low','cost_high']]) {
+      const f = meals.filter((m) => allowed.some((t) => mealTagsLower(m).includes(t)));
+      if (f.length) return f;
+    }
+  }
+  return meals;
+}
+
+function filterCuisine(meals, preferredCuisines) {
+  const cl = normalizeStringList(preferredCuisines);
+  if (!cl.length) return meals;
+  const f = meals.filter((m) => cl.some((c) => mealCuisinesLower(m).includes(c)));
+  return f.length ? f : meals;
+}
+
+function filterSeason(meals, preferredSeasons) {
+  const sl = normalizeStringList(preferredSeasons);
+  if (!sl.length) return meals;
+  const f = meals.filter((m) => {
+    const seasons = mealSeasonsLower(m);
+    return seasons.includes('all-season') || seasons.includes('all_season') || sl.some((s) => seasons.includes(s));
+  });
+  return f.length ? f : meals;
+}
+
+function filterTime(meals, { maxPrepTime, maxTotalTime }) {
+  if (maxPrepTime == null && maxTotalTime == null) return meals;
+  const f = meals.filter((m) => {
+    const prep = parseInt(m.prep_time_minutes) || 9999;
+    const total = parseInt(m.total_time_minutes) || (prep + (parseInt(m.cook_time_minutes) || 0));
+    if (maxPrepTime != null && prep > maxPrepTime) return false;
+    if (maxTotalTime != null && total > maxTotalTime) return false;
+    return true;
+  });
+  return f.length ? f : meals;
+}
+
+// ---- Scoring ----
+function conditionBoostScore(meal, conditionsLower) {
+  const tags = new Set(mealTagsLower(meal));
+  let score = 0;
+  for (const cond of conditionsLower) {
+    const preferred = CONDITION_PREFERENCE_MAP[cond] || [];
+    score += preferred.filter((t) => tags.has(t)).length * 8;
+  }
+  const sodium = Number(meal.sodium_mg) || 0;
+  if (conditionsLower.some((c) => c === 'hypertension' || c === 'high_blood_pressure') && sodium > 500) {
+    score -= Math.min(20, (sodium - 500) / 40);
+  }
+  return score;
+}
+
+function mealCalorieScore(meal, targetCalories) {
+  const calories = Number(meal.calories) || 0;
+  return Math.max(0, 50 - Math.abs(calories - targetCalories) * 0.25);
+}
+
+function varietyBonus(meal, usedCategories) {
+  const cats = new Set(mealCategoriesLower(meal));
+  if (!cats.size) return 0;
+  if ([...cats].every((c) => !usedCategories.has(c))) return 8;
+  const overlap = [...cats].filter((c) => usedCategories.has(c)).length;
+  return Math.max(0, 5 - overlap * 2);
+}
+
+function cultureSeasonBonus(meal, preferredCuisines, preferredSeasons) {
+  let score = 0;
+  const cuisines = new Set(mealCuisinesLower(meal));
+  const seasons = new Set(mealSeasonsLower(meal));
+  for (const c of preferredCuisines) if (cuisines.has(c)) score += 4;
+  for (const s of preferredSeasons) if (seasons.has(s) || seasons.has('all-season')) score += 2.5;
+  return score;
+}
+
+function sortPreferenceBonus(meal, sortBy) {
+  if (sortBy === 'prep_time') return Math.max(0, 12 - (parseInt(meal.prep_time_minutes) || 60) * 0.35);
+  if (sortBy === 'cook_time') return Math.max(0, 10 - (parseInt(meal.cook_time_minutes) || 60) * 0.25);
+  if (sortBy === 'total_time') return Math.max(0, 14 - (parseInt(meal.total_time_minutes) || 90) * 0.22);
+  if (sortBy === 'high_protein') return (Number(meal.protein_g) || 0) * 0.35;
+  if (sortBy === 'high_fibre') return (Number(meal.fibre_g) || 0) * 0.6;
+  if (sortBy === 'low_calories') return Math.max(0, 20 - (Number(meal.calories) || 0) * 0.03);
+  return 0;
+}
+
+function scoreMeal(meal, { targetCalories, remainingCalories, conditionsLower, usedCategories, preferredCuisines, preferredSeasons, sortBy }) {
+  const calories = parseInt(meal.calories) || 0;
+  if (calories > remainingCalories) return -1;
+  let score = mealCalorieScore(meal, targetCalories);
+  score += conditionBoostScore(meal, conditionsLower);
+  score += varietyBonus(meal, usedCategories);
+  score += cultureSeasonBonus(meal, preferredCuisines, preferredSeasons);
+  score += sortPreferenceBonus(meal, sortBy);
+  const tags = new Set(mealTagsLower(meal));
+  if (tags.has('processed_food') || new Set(mealCategoriesLower(meal)).has('fast_food')) score -= 6;
+  return score;
+}
+
+function pickBestMeal(meals, opts) {
+  const candidates = meals.filter((m) => !opts.excludedIds.has(m.id));
+  const scored = candidates
+    .map((m) => [scoreMeal(m, opts), m])
+    .filter(([s]) => s >= 0)
+    .sort((a, b) => b[0] - a[0]);
+  return scored.length ? scored[0][1] : null;
+}
+
+function buildNutritionSummary(planObj) {
+  const allMeals = [planObj.breakfast, planObj.lunch, planObj.dinner, ...(planObj.snacks || [])].filter(Boolean);
+  const summary = { protein_g: 0, carbs_g: 0, fat_g: 0, fibre_g: 0, sodium_mg: 0 };
+  for (const m of allMeals) {
+    for (const k of Object.keys(summary)) summary[k] += Number(m[k]) || 0;
+  }
+  return Object.fromEntries(Object.entries(summary).map(([k, v]) => [k, Math.round(v * 10) / 10]));
+}
+
+function buildRationale(meal, conditionsLower) {
+  if (!meal) return 'No meal matched the current constraints for this slot.';
+  const tags = new Set(mealTagsLower(meal));
+  const reasons = [];
+  if (tags.has('high_protein')) reasons.push('supports protein needs');
+  if (tags.has('high_fibre')) reasons.push('adds fibre for satiety');
+  if (tags.has('low_salt')) reasons.push('keeps sodium controlled');
+  if (tags.has('low_sugar') || tags.has('low_gi')) reasons.push('helps with glucose-friendly choices');
+  if (tags.has('heart_healthy') || tags.has('omega3_rich')) reasons.push('supports heart health');
+  for (const cond of conditionsLower) {
+    if ((CONDITION_PREFERENCE_MAP[cond] || []).some((t) => tags.has(t))) {
+      reasons.push(`aligned with ${cond.replace(/_/g, ' ')} preferences`);
+      break;
+    }
+  }
+  if (!reasons.length) reasons.push('fits current calorie and filtering constraints');
+  return [...new Set(reasons)].join('; ') + '.';
+}
+
+// ---- Main plan function ----
+function buildPlan(user) {
+  if (!user) user = {};
+  const allergies = normalizeStringList(normalizeList(user.allergies));
+  const conditionsLower = normalizeStringList(normalizeList(user.conditions));
+  const texture = user.texture || 'normal';
+  const budget = user.budget || 'medium';
+  const calories = parseInt(user.calories_target) || 2000;
+  const preferredCuisines = normalizeStringList(normalizeList(user.preferred_cuisines || []));
+  const preferredSeasons = normalizeStringList(normalizeList(user.preferred_seasons || []));
+  const maxPrepTime = user.max_prep_time_minutes != null ? parseInt(user.max_prep_time_minutes) : null;
+  const maxTotalTime = user.max_total_time_minutes != null ? parseInt(user.max_total_time_minutes) : null;
+  let sortBy = String(user.sort_by || 'balanced').trim().toLowerCase();
+  sortBy = SORT_ALIASES[sortBy] || sortBy;
+  if (!SORT_KEYS.has(sortBy)) sortBy = 'balanced';
+
+  let filtered = getMeals();
+  filtered = filterAllergy(filtered, allergies);
+  filtered = filterCondition(filtered, conditionsLower);
+  filtered = filterTexture(filtered, texture);
+
+  if (conditionsLower.includes('elderly')) {
+    const soft = filtered.filter((m) => mealTagsLower(m).includes('soft_food'));
+    if (soft.length) filtered = soft;
+  }
+
+  filtered = filterBudget(filtered, budget);
+  filtered = filterCuisine(filtered, preferredCuisines);
+  filtered = filterSeason(filtered, preferredSeasons);
+  filtered = filterTime(filtered, { maxPrepTime, maxTotalTime });
+
+  const breakfasts = filtered.filter((m) => m.meal_type === 'breakfast');
+  const lunches   = filtered.filter((m) => m.meal_type === 'lunch');
+  const dinners   = filtered.filter((m) => m.meal_type === 'dinner');
+  const snacks    = filtered.filter((m) => m.meal_type === 'snack');
+
+  let remainingCalories = calories;
+  const usedIds = new Set();
+  const usedCategories = new Set();
+  const planObj = { breakfast: null, lunch: null, dinner: null, snacks: [] };
+
+  const commonOpts = { conditionsLower, usedCategories, preferredCuisines, preferredSeasons, sortBy };
+
+  function pick(pool, targetCalories) {
+    return pickBestMeal(pool, { ...commonOpts, targetCalories, remainingCalories, excludedIds: usedIds });
+  }
+
+  function apply(slot, meal) {
+    planObj[slot] = meal;
+    if (meal) {
+      remainingCalories -= parseInt(meal.calories) || 0;
+      usedIds.add(meal.id);
+      for (const c of mealCategoriesLower(meal)) usedCategories.add(c);
+    }
+  }
+
+  apply('breakfast', pick(breakfasts, calories * MEAL_TYPE_CALORIE_DISTRIBUTION.breakfast));
+  apply('lunch',     pick(lunches,    calories * MEAL_TYPE_CALORIE_DISTRIBUTION.lunch));
+
+  let dinner = pick(dinners, calories * MEAL_TYPE_CALORIE_DISTRIBUTION.dinner);
+  if (!dinner) {
+    const soft = dinners.filter((m) => mealTagsLower(m).includes('soft_food'));
+    dinner = pick(soft, calories * MEAL_TYPE_CALORIE_DISTRIBUTION.dinner);
+  }
+  apply('dinner', dinner);
+
+  const snackTarget = calories * MEAL_TYPE_CALORIE_DISTRIBUTION.snack;
+  const sortedSnacks = snacks
+    .map((m) => [scoreMeal(m, { ...commonOpts, targetCalories: Math.max(snackTarget / 2, 80), remainingCalories, excludedIds: usedIds }), m])
+    .filter(([s]) => s >= 0)
+    .sort((a, b) => b[0] - a[0])
+    .map(([, m]) => m);
+
+  function addSnack(snack, requireNewCategory) {
+    if (planObj.snacks.length >= 2 || usedIds.has(snack.id)) return false;
+    if ((parseInt(snack.calories) || 0) > remainingCalories) return false;
+    const snackCats = new Set(mealCategoriesLower(snack));
+    if (requireNewCategory && snackCats.size && [...snackCats].some((c) => usedCategories.has(c))) return false;
+    planObj.snacks.push(snack);
+    remainingCalories -= parseInt(snack.calories) || 0;
+    usedIds.add(snack.id);
+    for (const c of snackCats) usedCategories.add(c);
+    return true;
+  }
+
+  for (const s of sortedSnacks) { if (planObj.snacks.length >= 2) break; addSnack(s, true); }
+  if (!planObj.snacks.length) for (const s of sortedSnacks) { if (planObj.snacks.length >= 2) break; addSnack(s, false); }
+
+  const totalCalories = [planObj.breakfast, planObj.lunch, planObj.dinner, ...planObj.snacks]
+    .filter(Boolean).reduce((sum, m) => sum + (parseInt(m.calories) || 0), 0);
+
+  planObj.total_calories = totalCalories;
+  planObj.target_calories = calories;
+  planObj.allergies_used = allergies;
+  planObj.budget_used = budget;
+  planObj.conditions_used = conditionsLower;
+  planObj.remaining_calories = remainingCalories;
+  planObj.daily_nutrition_summary = buildNutritionSummary(planObj);
+  planObj.variety_score = usedCategories.size;
+  planObj.sorting_used = sortBy;
+  planObj.cuisine_filter_used = preferredCuisines;
+  planObj.season_filter_used = preferredSeasons;
+  planObj.max_prep_time_minutes_used = maxPrepTime;
+  planObj.max_total_time_minutes_used = maxTotalTime;
+  planObj.meal_rationales = {
+    breakfast: buildRationale(planObj.breakfast, conditionsLower),
+    lunch: buildRationale(planObj.lunch, conditionsLower),
+    dinner: buildRationale(planObj.dinner, conditionsLower),
+    snacks: (planObj.snacks || []).map((s) => buildRationale(s, conditionsLower)),
+  };
+
+  return planObj;
+}
+
+// POST /ai-model/meal-plan/generate
+router.post('/generate', (req, res) => {
+  try {
+    const result = buildPlan(req.body || {});
+    if (!result.breakfast && !result.lunch && !result.dinner) {
+      return res.status(400).json({ error: 'No meals available after filtering. Try relaxing allergies/conditions/texture/budget.' });
+    }
+    return res.json(result);
+  } catch (err) {
+    return res.status(500).json({ error: 'Meal plan generation failed due to server error.' });
+  }
+});
+
+module.exports = router;

--- a/routes/ai/medicalReport.js
+++ b/routes/ai/medicalReport.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const medicalPredictionController = require('../../controller/medicalPredictionController');
+
+// POST /ai-model/medical-report/retrieve
+router.post('/retrieve', medicalPredictionController.predict);
+
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -51,4 +51,9 @@ module.exports = app => {
     // AI model routes (ported from NutriHelp-ai)
     app.use('/ai-model/chatbot', require('./ai/chatbot'));
     app.use('/ai-model/medical-report/plan', require('./ai/healthPlan'));
+    app.use('/ai-model/medical-report', require('./ai/medicalReport'));
+    app.use('/ai-model/image-analysis', require('./ai/imageAnalysis'));
+    app.use('/ai-model/meals', require('./ai/mealLog'));
+    app.use('/ai-model/meal-plan', require('./ai/mealPlan'));
+    app.use('/ai-model/chatbot-finetune', require('./ai/finetuneChat'));
 };

--- a/services/mealLogService.js
+++ b/services/mealLogService.js
@@ -1,0 +1,193 @@
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const nutritionLookup = require('./nutritionLookupService');
+
+const DATA_PATH = path.join(__dirname, '..', 'data', 'meal_logs.json');
+
+function ensureFile() {
+  const dir = path.dirname(DATA_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  if (!fs.existsSync(DATA_PATH)) fs.writeFileSync(DATA_PATH, '[]', 'utf8');
+}
+
+function loadEntries() {
+  try {
+    ensureFile();
+    return JSON.parse(fs.readFileSync(DATA_PATH, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function saveEntries(entries) {
+  ensureFile();
+  fs.writeFileSync(DATA_PATH, JSON.stringify(entries, null, 2), 'utf8');
+}
+
+function normalizeUserId(userId) {
+  const val = String(userId || 'anonymous').trim();
+  return val || 'anonymous';
+}
+
+function normalizeDate(value) {
+  if (!value) return new Date().toISOString().split('T')[0];
+  const d = new Date(value);
+  if (isNaN(d.getTime())) throw new Error(`Invalid date: ${value}`);
+  return d.toISOString().split('T')[0];
+}
+
+function createEntry(payload) {
+  const entryDate = normalizeDate(payload.date);
+  const userId = normalizeUserId(payload.user_id);
+  const nutrition = nutritionLookup.lookup(payload.label);
+
+  const estimatedCalories = payload.estimated_calories != null
+    ? payload.estimated_calories
+    : nutrition.estimated_calories;
+
+  const servingDescription = payload.serving_description || nutrition.serving_description;
+
+  const entry = {
+    id: uuidv4(),
+    user_id: userId,
+    date: entryDate,
+    meal_type: payload.meal_type || 'Snacks',
+    label: payload.label,
+    confidence: payload.confidence != null ? payload.confidence : 0,
+    estimated_calories: estimatedCalories,
+    serving_description: servingDescription,
+    recommendation: payload.recommendation || null,
+    is_unclear: payload.is_unclear || false,
+    quality_issues: Array.isArray(payload.quality_issues) ? payload.quality_issues : [],
+    source: payload.source || 'scan',
+    created_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+  };
+
+  const entries = loadEntries();
+  entries.push(entry);
+  saveEntries(entries);
+  return entry;
+}
+
+function deleteEntry(entryId, userId) {
+  const normalizedUser = normalizeUserId(userId);
+  const entries = loadEntries();
+  const next = entries.filter((e) => !(e.id === entryId && e.user_id === normalizedUser));
+  const deleted = next.length < entries.length;
+  if (deleted) saveEntries(next);
+  return deleted;
+}
+
+function listEntries({ targetDate, userId } = {}) {
+  const normalizedUser = normalizeUserId(userId);
+  const normalizedDate = targetDate ? normalizeDate(targetDate) : null;
+  const entries = loadEntries()
+    .filter((e) => e.user_id === normalizedUser && (normalizedDate === null || e.date === normalizedDate))
+    .sort((a, b) => {
+      if (a.date !== b.date) return b.date.localeCompare(a.date);
+      if (a.created_at !== b.created_at) return b.created_at.localeCompare(a.created_at);
+      return b.id.localeCompare(a.id);
+    });
+  return entries;
+}
+
+function getDailySummary({ targetDate, userId } = {}) {
+  const normalizedUser = normalizeUserId(userId);
+  const normalizedDate = normalizeDate(targetDate);
+  const meals = listEntries({ targetDate: normalizedDate, userId: normalizedUser });
+
+  const totalCalories = meals.reduce((sum, m) => sum + (parseInt(m.estimated_calories) || 0), 0);
+  const unclearCount = meals.filter((m) => m.is_unclear).length;
+  const mealTypeBreakdown = { Breakfast: 0, Lunch: 0, Dinner: 0, Snacks: 0 };
+  for (const m of meals) {
+    mealTypeBreakdown[m.meal_type] = (mealTypeBreakdown[m.meal_type] || 0) + 1;
+  }
+
+  return {
+    user_id: normalizedUser,
+    date: normalizedDate,
+    total_calories: totalCalories,
+    entry_count: meals.length,
+    unclear_count: unclearCount,
+    meal_type_breakdown: mealTypeBreakdown,
+    meals,
+  };
+}
+
+function buildChatContext({ targetDate, userId } = {}) {
+  const summary = getDailySummary({ targetDate, userId });
+  if (!summary.meals.length) {
+    return {
+      user_id: summary.user_id,
+      date: summary.date,
+      has_data: false,
+      summary: 'No meals have been logged for that day.',
+      prompt_context: '',
+    };
+  }
+
+  const mealLines = summary.meals.slice(0, 8).map((m) => {
+    const calText = m.estimated_calories != null ? `${m.estimated_calories} kcal` : 'calories unavailable';
+    return `- ${m.meal_type}: ${m.label} (${calText}, confidence ${Number(m.confidence).toFixed(2)})`;
+  });
+
+  const summaryText = `On ${summary.date}, the user logged ${summary.entry_count} meals totaling about ${summary.total_calories} kcal.`;
+  const promptContext = `Use the following logged meals as recent dietary context. Treat calorie values as rough estimates, not exact nutrition facts.\nMeal date: ${summary.date}\n${mealLines.join('\n')}`;
+
+  return {
+    user_id: summary.user_id,
+    date: summary.date,
+    has_data: true,
+    summary: summaryText,
+    prompt_context: promptContext,
+  };
+}
+
+function buildPlanContext({ userId, dateTo, days = 7 } = {}) {
+  const normalizedUser = normalizeUserId(userId);
+  const safeDays = Math.max(1, parseInt(days) || 7);
+  const endDate = new Date(normalizeDate(dateTo));
+
+  const dailySummaries = [];
+  const foodCounter = {};
+  let totalCalories = 0;
+  let loggedDays = 0;
+
+  for (let offset = 0; offset < safeDays; offset++) {
+    const current = new Date(endDate);
+    current.setDate(endDate.getDate() - (safeDays - 1 - offset));
+    const dateStr = current.toISOString().split('T')[0];
+    const summary = getDailySummary({ targetDate: dateStr, userId: normalizedUser });
+    dailySummaries.push(summary);
+    if (summary.entry_count > 0) {
+      loggedDays++;
+      totalCalories += summary.total_calories;
+      for (const m of summary.meals) {
+        foodCounter[m.label] = (foodCounter[m.label] || 0) + 1;
+      }
+    }
+  }
+
+  const average = loggedDays > 0 ? totalCalories / loggedDays : 0;
+  const topFoods = Object.entries(foodCounter)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([label]) => label);
+
+  const startDate = new Date(endDate);
+  startDate.setDate(endDate.getDate() - (safeDays - 1));
+
+  return {
+    user_id: normalizedUser,
+    date_from: startDate.toISOString().split('T')[0],
+    date_to: endDate.toISOString().split('T')[0],
+    days: safeDays,
+    average_daily_calories: Math.round(average * 10) / 10,
+    top_foods: topFoods,
+    summary: `Over the last ${safeDays} day(s), the user logged meals on ${loggedDays} day(s) with an average of ${average.toFixed(1)} kcal on logged days.`,
+    daily_summaries: dailySummaries,
+  };
+}
+
+module.exports = { createEntry, deleteEntry, listEntries, getDailySummary, buildChatContext, buildPlanContext };

--- a/services/nutritionLookupService.js
+++ b/services/nutritionLookupService.js
@@ -1,0 +1,151 @@
+const EXACT_LOOKUP = {
+  apple_pie: { estimated_calories: 320, serving_description: '1 slice' },
+  bibimbap: { estimated_calories: 560, serving_description: '1 bowl' },
+  caesar_salad: { estimated_calories: 280, serving_description: '1 bowl' },
+  cheesecake: { estimated_calories: 430, serving_description: '1 slice' },
+  chicken_curry: { estimated_calories: 420, serving_description: '1 bowl' },
+  chicken_wings: { estimated_calories: 430, serving_description: '6 wings' },
+  chocolate_cake: { estimated_calories: 410, serving_description: '1 slice' },
+  club_sandwich: { estimated_calories: 520, serving_description: '1 sandwich' },
+  donuts: { estimated_calories: 260, serving_description: '1 donut' },
+  falafel: { estimated_calories: 330, serving_description: '1 serving' },
+  fish_and_chips: { estimated_calories: 680, serving_description: '1 plate' },
+  french_fries: { estimated_calories: 365, serving_description: '1 medium serve' },
+  fried_rice: { estimated_calories: 450, serving_description: '1 plate' },
+  grilled_salmon: { estimated_calories: 360, serving_description: '1 fillet' },
+  guacamole: { estimated_calories: 230, serving_description: '1 small bowl' },
+  hamburger: { estimated_calories: 520, serving_description: '1 burger' },
+  hot_dog: { estimated_calories: 330, serving_description: '1 hot dog' },
+  hummus: { estimated_calories: 180, serving_description: '1 small bowl' },
+  ice_cream: { estimated_calories: 275, serving_description: '1 cup' },
+  lasagna: { estimated_calories: 430, serving_description: '1 slice' },
+  macaroni_and_cheese: { estimated_calories: 460, serving_description: '1 bowl' },
+  nachos: { estimated_calories: 520, serving_description: '1 plate' },
+  omelette: { estimated_calories: 250, serving_description: '1 omelette' },
+  pad_thai: { estimated_calories: 540, serving_description: '1 plate' },
+  pancakes: { estimated_calories: 350, serving_description: '3 pancakes' },
+  pho: { estimated_calories: 380, serving_description: '1 bowl' },
+  pizza: { estimated_calories: 285, serving_description: '1 slice' },
+  ramen: { estimated_calories: 490, serving_description: '1 bowl' },
+  risotto: { estimated_calories: 420, serving_description: '1 bowl' },
+  sashimi: { estimated_calories: 220, serving_description: '1 serving' },
+  spaghetti_bolognese: { estimated_calories: 520, serving_description: '1 plate' },
+  spaghetti_carbonara: { estimated_calories: 610, serving_description: '1 plate' },
+  steak: { estimated_calories: 620, serving_description: '1 steak' },
+  sushi: { estimated_calories: 320, serving_description: '1 roll set' },
+  tacos: { estimated_calories: 300, serving_description: '2 tacos' },
+  tiramisu: { estimated_calories: 390, serving_description: '1 slice' },
+  waffles: { estimated_calories: 370, serving_description: '2 waffles' },
+  avocado_toast: { estimated_calories: 310, serving_description: '1 slice' },
+  greek_salad: { estimated_calories: 240, serving_description: '1 bowl' },
+  quinoa_salad: { estimated_calories: 320, serving_description: '1 bowl' },
+  chickpea_salad: { estimated_calories: 340, serving_description: '1 bowl' },
+  tofu_stir_fry: { estimated_calories: 410, serving_description: '1 bowl' },
+  burrito_bowl: { estimated_calories: 540, serving_description: '1 bowl' },
+  overnight_oats: { estimated_calories: 300, serving_description: '1 jar' },
+  protein_smoothie: { estimated_calories: 260, serving_description: '1 glass' },
+  grilled_chicken_bowl: { estimated_calories: 460, serving_description: '1 bowl' },
+  lentil_soup: { estimated_calories: 280, serving_description: '1 bowl' },
+  salmon_bowl: { estimated_calories: 520, serving_description: '1 bowl' },
+  veggie_wrap: { estimated_calories: 360, serving_description: '1 wrap' },
+  bean_chili: { estimated_calories: 390, serving_description: '1 bowl' },
+  cottage_cheese_bowl: { estimated_calories: 220, serving_description: '1 bowl' },
+  chana_masala: { estimated_calories: 430, serving_description: '1 bowl' },
+  kimchi_bibimbap: { estimated_calories: 570, serving_description: '1 bowl' },
+  thai_basil_chicken: { estimated_calories: 520, serving_description: '1 plate' },
+  turkish_lentil_soup: { estimated_calories: 290, serving_description: '1 bowl' },
+  falafel_wrap: { estimated_calories: 480, serving_description: '1 wrap' },
+  shakshuka: { estimated_calories: 360, serving_description: '1 skillet serve' },
+  mojo_fish: { estimated_calories: 510, serving_description: '1 plate' },
+  black_bean_rice: { estimated_calories: 520, serving_description: '1 bowl' },
+  onigiri: { estimated_calories: 190, serving_description: '2 pieces' },
+  dal_khichdi: { estimated_calories: 500, serving_description: '1 bowl' },
+};
+
+const KEYWORD_FALLBACKS = [
+  ['salad', { estimated_calories: 220, serving_description: '1 bowl' }],
+  ['soup',  { estimated_calories: 180, serving_description: '1 bowl' }],
+  ['cake',  { estimated_calories: 410, serving_description: '1 slice' }],
+  ['sandwich', { estimated_calories: 480, serving_description: '1 sandwich' }],
+];
+
+const LABEL_ALIASES = {
+  'apple pie': 'apple_pie', 'caesar salad': 'caesar_salad', 'chicken curry': 'chicken_curry',
+  'chicken wings': 'chicken_wings', 'chocolate cake': 'chocolate_cake', 'club sandwich': 'club_sandwich',
+  'fish and chips': 'fish_and_chips', 'french fries': 'french_fries', 'fried rice': 'fried_rice',
+  'grilled salmon': 'grilled_salmon', 'hot dog': 'hot_dog', 'ice cream': 'ice_cream',
+  'macaroni and cheese': 'macaroni_and_cheese', 'pad thai': 'pad_thai',
+  'spaghetti bolognese': 'spaghetti_bolognese', 'spaghetti carbonara': 'spaghetti_carbonara',
+  'avocado toast': 'avocado_toast', 'greek salad': 'greek_salad', 'quinoa salad': 'quinoa_salad',
+  'tofu stir fry': 'tofu_stir_fry', 'overnight oats': 'overnight_oats',
+  'protein smoothie': 'protein_smoothie', 'burrito bowl': 'burrito_bowl', 'bean chili': 'bean_chili',
+  'chana masala': 'chana_masala', 'kimchi bibimbap': 'kimchi_bibimbap',
+  'thai basil chicken': 'thai_basil_chicken', 'turkish lentil soup': 'turkish_lentil_soup',
+  'falafel wrap': 'falafel_wrap', 'black bean rice': 'black_bean_rice',
+  'mojo fish': 'mojo_fish', 'dal khichdi': 'dal_khichdi',
+};
+
+function normalizeLabel(label) {
+  if (!label) return '';
+  let text = String(label).trim().toLowerCase();
+  text = LABEL_ALIASES[text] || text;
+  text = text.replace(/[^a-z0-9\s_-]+/g, '').replace(/[\s-]+/g, '_');
+  return LABEL_ALIASES[text] || text;
+}
+
+function humanizeLabel(label) {
+  if (!label) return 'Unknown Dish';
+  return label.replace(/_/g, ' ').trim().replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function unavailable(label) {
+  const normalized = normalizeLabel(label);
+  return {
+    display_name: humanizeLabel(normalized || label),
+    about: null, cuisine: null,
+    estimated_calories: null, serving_description: null,
+    protein_g: null, carbs_g: null, fat_g: null, fibre_g: null,
+    sugar_g: null, sodium_mg: null,
+    micronutrients: {}, vitamins: [], minerals: [], allergens: [], food_categories: [],
+    source: 'unavailable', available: false,
+  };
+}
+
+function lookup(label) {
+  if (!label) return unavailable(null);
+  const normalized = normalizeLabel(label);
+  const displayName = humanizeLabel(normalized || label);
+
+  if (EXACT_LOOKUP[normalized]) {
+    const data = EXACT_LOOKUP[normalized];
+    return {
+      display_name: displayName,
+      about: null, cuisine: null,
+      estimated_calories: data.estimated_calories,
+      serving_description: data.serving_description,
+      protein_g: 0, carbs_g: 0, fat_g: 0, fibre_g: 0,
+      sugar_g: 0, sodium_mg: 0,
+      micronutrients: {}, vitamins: [], minerals: [], allergens: [], food_categories: [],
+      source: 'curated_lookup', available: true,
+    };
+  }
+
+  for (const [keyword, data] of KEYWORD_FALLBACKS) {
+    if (normalized.includes(keyword)) {
+      return {
+        display_name: displayName,
+        about: null, cuisine: null,
+        estimated_calories: data.estimated_calories,
+        serving_description: data.serving_description,
+        protein_g: 0, carbs_g: 0, fat_g: 0, fibre_g: 0,
+        sugar_g: 0, sodium_mg: 0,
+        micronutrients: {}, vitamins: [], minerals: [], allergens: [], food_categories: [],
+        source: 'category_heuristic', available: true,
+      };
+    }
+  }
+
+  return unavailable(label);
+}
+
+module.exports = { lookup };


### PR DESCRIPTION
## Summary

- **Port 6 remaining AI routers** from NutriHelp-AI (Python/FastAPI) into Nutrihelp-api (Node/Express) as JavaScript re-implementations, completing the full 8/8 router sync
- All new routes are registered under the `/ai-model/*` prefix for compatibility with the mobile app (`NutriHelp-App-2026`)

## New files

| File | Route(s) |
|------|----------|
| `routes/ai/medicalReport.js` | `POST /ai-model/medical-report/retrieve` |
| `routes/ai/imageAnalysis.js` | `POST /ai-model/image-analysis/image-analysis` · `POST /ai-model/image-analysis/multi-image-analysis` |
| `routes/ai/mealLog.js` | 7 endpoints under `/ai-model/meals/*` (log-scan, logs, daily-summary, chat-context, plan-context, delete) |
| `routes/ai/mealPlan.js` | `POST /ai-model/meal-plan/generate` — full port of meal_generator.py with allergy/condition filtering and scoring |
| `routes/ai/finetuneChat.js` | `GET /ai-model/chatbot-finetune/healthz` · `POST /ai-model/chatbot-finetune/chat` (proxies HuggingFace Space) |
| `services/mealLogService.js` | JSON file-based meal log storage (port of Python meal_log_service.py) |
| `services/nutritionLookupService.js` | Nutrition lookup with EXACT_LOOKUP dict + keyword fallback (port of nutrition_lookup.py) |
| `data/meal_library.json` | Meal database used by meal plan generation |

## Modified files

- `routes/index.js` — register 5 new `/ai-model/*` route prefixes
- `.gitignore` — add `!data/meal_library.json` exception so the meal library is tracked

## Test plan

- [ ] `POST /ai-model/medical-report/retrieve` — returns medical prediction
- [ ] `POST /ai-model/image-analysis/image-analysis` — single image classification
- [ ] `POST /ai-model/image-analysis/multi-image-analysis` — multi-image classification
- [ ] `POST /ai-model/meals/log-scan` — creates meal log entry, returns entry + daily summary
- [ ] `GET /ai-model/meals/logs?date=&user_id=` — list meal logs
- [ ] `GET /ai-model/meals/daily-summary` — returns calorie totals and breakdown
- [ ] `POST /ai-model/meal-plan/generate` — returns full day plan with rationale
- [ ] `GET /ai-model/chatbot-finetune/healthz` — HuggingFace Space health check
- [ ] `POST /ai-model/chatbot-finetune/chat` — fine-tuned chatbot response