### PR TITLE
CS-1: Store privacy consent during registration

### DIFF
--- a/controller/authController.js
+++ b/controller/authController.js
@@ -58,7 +58,16 @@ function handleServiceError(res, error, fallbackStatus, fallbackCode, label, con
 
 exports.register = async (req, res) => {
   try {
-    const { name, email, password, first_name, last_name } = req.body;
+    const {
+      name,
+      email,
+      password,
+      first_name,
+      last_name,
+      contact_number,
+      address,
+      privacy_consent
+    } = req.body;
 
     if (!name || !email || !password) {
       return res.status(400).json(
@@ -71,7 +80,10 @@ exports.register = async (req, res) => {
       email,
       password,
       first_name,
-      last_name
+      last_name,
+      contact_number,
+      address,
+      privacy_consent
     });
 
     return res.status(201).json(createSuccessResponse({

--- a/database/migrations/002_add_privacy_consent_fields.sql
+++ b/database/migrations/002_add_privacy_consent_fields.sql
@@ -1,0 +1,6 @@
+-- CS-1: Privacy Policy & Consent Flow
+-- Adds an auditable record of privacy-policy consent to each user.
+
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS privacy_consent_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS privacy_policy_version TEXT;

--- a/services/authService.js
+++ b/services/authService.js
@@ -167,11 +167,30 @@ class AuthService {
      Register
      ========================= */
   async register(userData) {
-    const { name, email, password, first_name, last_name } = userData;
+    const {
+      name,
+      email,
+      password,
+      first_name,
+      last_name,
+      contact_number,
+      address,
+      privacy_consent
+    } = userData;
 
     try {
       if (!name || !email || !password) {
-        throw new ServiceError(400, 'Name, email, and password are required');
+        throw new ServiceError(
+          400,
+          'Name, email, and password are required'
+        );
+      }
+
+      if (privacy_consent !== true) {
+        throw new ServiceError(
+          400,
+          'Privacy policy consent is required'
+        );
       }
 
       const { data: existingUser } = await supabaseAnon
@@ -194,16 +213,22 @@ class AuthService {
           password: hashedPassword,
           first_name,
           last_name,
+          contact_number,
+          address,
           role_id: 7,
           account_status: 'active',
           email_verified: false,
           mfa_enabled: false,
-          registration_date: new Date().toISOString()
+          registration_date: new Date().toISOString(),
+          privacy_consent_at: new Date().toISOString(),
+          privacy_policy_version: '1.0'
         })
         .select('user_id, email, name')
         .single();
 
-      if (error) throw error;
+      if (error) {
+        throw error;
+      }
 
       return {
         success: true,
@@ -215,7 +240,10 @@ class AuthService {
         throw error;
       }
 
-      throw new ServiceError(400, `Registration failed: ${error.message}`);
+      throw new ServiceError(
+        400,
+        `Registration failed: ${error.message}`
+      );
     }
   }
 
@@ -481,7 +509,7 @@ class AuthService {
         .eq('is_active', true)
         .limit(1);
 
-      
+
       if (error || !sessions || sessions.length === 0) {
         throw new ServiceError(401, 'Invalid refresh token');
       }

--- a/validators/signupValidator.js
+++ b/validators/signupValidator.js
@@ -24,6 +24,10 @@ const registerValidation = [
   body('address')
     .notEmpty().withMessage('Address is required')
     .isLength({ min: 10 }).withMessage('Address should be at least 10 characters long'),
+
+  body('privacy_consent')
+    .equals('true')
+    .withMessage('Privacy policy consent is required'),
 ];
 
 module.exports = { registerValidation };


### PR DESCRIPTION
## Summary

Implements the backend portion of CS-1 Privacy Policy & Consent Flow.

## Changes

- Added validation requiring `privacy_consent` during registration
- Passed consent data through the registration controller
- Added server-generated consent timestamp storage
- Added privacy policy version storage using version `1.0`
- Added an SQL migration for:
  - `privacy_consent_at`
  - `privacy_policy_version`

## Testing

- Confirmed registration without consent returns HTTP 400
- Confirmed registration with consent passes validation and reaches the database insert
- Confirmed the current failure is caused only by the missing database columns
- Confirmed modified backend files pass JavaScript syntax checks

## Database note

The SQL migration has been committed for review but has not been applied to Supabase.

Successful end-to-end registration will remain blocked until the migration is reviewed and applied to the relevant database.

## Related frontend work

A separate Nutrihelp-web pull request contains the privacy policy page, consent checkbox, validation, policy link, Google signup consent check, and structured error handling.