### PR TITLE
Fix premature route module closure

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -52,7 +52,7 @@ module.exports = app => {
     app.use('/security-dashboard', require('./securityDashboard'));
     app.use('/api/recommendations', require('./recommendations'));
     app.use('/api/meal-plan', require('./mealPlanAIRoutes'));
-};
+
 
     // AI model routes (ported from NutriHelp-ai)
     app.use('/ai-model/chatbot', require('./ai/chatbot'));


### PR DESCRIPTION
## Summary

Fixed the syntax issue in `routes/index.js` from PR# 256 merge. The route module was closed prematurely before the AI model routes were registered.

## Files Updated

* **routes/index.js**
  Removed the premature closing `};` so all application and AI model routes remain inside the exported route configuration function.

## Testing

* Confirmed the backend starts successfully after the fix.
* Verified Swagger loads correctly.
* Confirmed existing route registrations remain intact.
* Verified only `routes/index.js` was modified by this fix.
